### PR TITLE
🐛 Fix version numbers, other little things

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,15 +11,14 @@ For example, to use the quickstart test, we should do something like:
 ```
 echo hello-world >sample.txt
 bin/opentdf.mjs encrypt \
-  --kasEndpoint http://localhost:65432/kas \
-  --oidcEndpoint http://localhost:65432/keycloak \
+  --kasEndpoint http://localhost:65432/api/kas \
+  --oidcEndpoint http://localhost:65432 \
   --auth tdf:tdf-client:123-456 \
-  --attributes http://opentdf-kas/attr/default/value/default \
   --output sample.tdf \
   sample.txt
 bin/opentdf.mjs \
-  --kasEndpoint http://localhost:65432/kas \
-  --oidcEndpoint http://localhost:65432/keycloak \
+  --kasEndpoint http://localhost:65432/api/kas \
+  --oidcEndpoint http://localhost:65432 \
   --auth tdf:tdf-client:123-456 \
   decrypt sample.tdf
 ```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@opentdf/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opentdf/cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
-        "@opentdf/client": "file:../opentdf-client-0.1.0.tgz",
-        "cross-fetch": "^3.1.5",
+        "@opentdf/client": "file:../opentdf-client-0.1.1.tgz",
         "yargs": "^17.4.0"
       },
       "bin": {
@@ -141,12 +140,13 @@
       }
     },
     "node_modules/@opentdf/client": {
-      "version": "0.1.0",
-      "resolved": "file:../opentdf-client-0.1.0.tgz",
-      "integrity": "sha512-ssP6C+A3BKZlwPG8/nOOhkHJra0HUjhU4xtT9PUhTlsYOwona93ARwislW+LcSNW2GK2moYGj+u42CdCEMfDyg==",
+      "version": "0.1.1",
+      "resolved": "file:../opentdf-client-0.1.1.tgz",
+      "integrity": "sha512-IccSBhLxKoCgNsScZ+BtRfo7v/FhM9h50XqtiicbDSpNYrBzrCWdwStpdUQ7jBKn1VDjpBJ0ODwDJn3p/THI5A==",
       "license": "MIT",
       "dependencies": {
         "jose": "~4.6.0",
+        "node-fetch": "^3.2.3",
         "uuid": "~8.3.2"
       }
     },
@@ -809,14 +809,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -829,6 +821,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -1252,6 +1252,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1319,6 +1341,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1633,9 +1666,9 @@
       "dev": true
     },
     "node_modules/jose": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
-      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.2.tgz",
+      "integrity": "sha512-7Jd3kGkgDfhpj+SFqfam70HyVC0gtdfbGc/tHb5dqsWYlQqodgkotqWYEXn1PhQXgdJqsyOAIKT0N4O2riUFiA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2022,23 +2055,39 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
+      "integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nopt": {
@@ -2702,11 +2751,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "node_modules/treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -2880,18 +2924,12 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -3117,10 +3155,11 @@
       }
     },
     "@opentdf/client": {
-      "version": "file:../opentdf-client-0.1.0.tgz",
-      "integrity": "sha512-ssP6C+A3BKZlwPG8/nOOhkHJra0HUjhU4xtT9PUhTlsYOwona93ARwislW+LcSNW2GK2moYGj+u42CdCEMfDyg==",
+      "version": "file:../opentdf-client-0.1.1.tgz",
+      "integrity": "sha512-IccSBhLxKoCgNsScZ+BtRfo7v/FhM9h50XqtiicbDSpNYrBzrCWdwStpdUQ7jBKn1VDjpBJ0ODwDJn3p/THI5A==",
       "requires": {
         "jose": "~4.6.0",
+        "node-fetch": "^3.2.3",
         "uuid": "~8.3.2"
       }
     },
@@ -3605,14 +3644,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3623,6 +3654,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
     },
     "debug": {
       "version": "4.3.3",
@@ -3940,6 +3976,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3989,6 +4034,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4218,9 +4271,9 @@
       "dev": true
     },
     "jose": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
-      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.2.tgz",
+      "integrity": "sha512-7Jd3kGkgDfhpj+SFqfam70HyVC0gtdfbGc/tHb5dqsWYlQqodgkotqWYEXn1PhQXgdJqsyOAIKT0N4O2riUFiA=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -4534,12 +4587,19 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
+      "integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "nopt": {
@@ -5021,11 +5081,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -5145,19 +5200,10 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentdf/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node based CLI for opentdf",
   "repository": {
     "type": "git",
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "@opentdf/client": "file:../opentdf-client-0.1.1.tgz",
-    "cross-fetch": "^3.1.5",
     "yargs": "^17.4.0"
   }
 }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,20 +1,9 @@
 import yargs from 'yargs';
 import { readFile, stat, writeFile } from 'fs/promises';
-import { webcrypto } from 'crypto';
-
 import { hideBin } from 'yargs/helpers';
 import { AuthProviders, NanoTDFClient, version } from '@opentdf/client';
 
 import { CLIError, Level, log } from './logger.js';
-
-// Load global 'fetch' functions
-import 'cross-fetch/dist/node-polyfill.js';
-
-declare global {
-  // polyfill for browser crypto
-  // eslint-disable-next-line no-var
-  var crypto: typeof webcrypto;
-}
 
 type AuthToProcess = {
   auth?: string;

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@opentdf/client",
-      "version": "0.2.5",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "jose": "~4.6.0",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -127,7 +127,7 @@ export class NanoTDFClient extends Client {
       policy.addAttribute(attribute);
     }
 
-    if (this.dissems.length == 0 || this.dataAttributes.length == 0) {
+    if (this.dissems.length == 0 && this.dataAttributes.length == 0) {
       console.warn(
         'This policy has an empty attributes list and an empty dissemination list. This will allow any entity with a valid Entity Object to access this TDF.'
       );

--- a/sample-web-app/package-lock.json
+++ b/sample-web-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opentdf/sample-web-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opentdf/sample-web-app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@opentdf/client": "file:../opentdf-client-0.1.1.tgz",
@@ -735,7 +735,7 @@
     "node_modules/@opentdf/client": {
       "version": "0.1.1",
       "resolved": "file:../opentdf-client-0.1.1.tgz",
-      "integrity": "sha512-QSy4GOfz7d0X8rFU0huekTIynI6tQJw3EgCrtIAETPvosqXP4aQiDW2n8j5EaLeQC+Oyh6ePYlK9mVDPKH1yrg==",
+      "integrity": "sha512-IccSBhLxKoCgNsScZ+BtRfo7v/FhM9h50XqtiicbDSpNYrBzrCWdwStpdUQ7jBKn1VDjpBJ0ODwDJn3p/THI5A==",
       "license": "MIT",
       "dependencies": {
         "jose": "~4.6.0",
@@ -9742,7 +9742,7 @@
     },
     "@opentdf/client": {
       "version": "file:../opentdf-client-0.1.1.tgz",
-      "integrity": "sha512-QSy4GOfz7d0X8rFU0huekTIynI6tQJw3EgCrtIAETPvosqXP4aQiDW2n8j5EaLeQC+Oyh6ePYlK9mVDPKH1yrg==",
+      "integrity": "sha512-IccSBhLxKoCgNsScZ+BtRfo7v/FhM9h50XqtiicbDSpNYrBzrCWdwStpdUQ7jBKn1VDjpBJ0ODwDJn3p/THI5A==",
       "requires": {
         "jose": "~4.6.0",
         "node-fetch": "^3.2.3",

--- a/sample-web-app/package.json
+++ b/sample-web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentdf/sample-web-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Sets cli and sample app version numbers to 0.1.1
- updates package-locks to reflect correct version numbers
- removes some no-longer needed polyfill stuff from cli, since we now have nodejs support in lib
- don't warn about empty policies if dissems OR attributes are empty, but if dissems AND attributes are empty
- Update the cli readme for the latest quickstart URIs