### PR TITLE
➖ Removes unused dep on ua-parser

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -191,20 +191,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.130.0.tgz",
-      "integrity": "sha512-JA/3T8U/fZZZvrpLIdv4HDoL7JrbvW5SERe3ni6UtqlW6y9jlfS824KmBnKSzVdSwdn6qzl6k9Z/xN2hDa+Qdw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.131.0.tgz",
+      "integrity": "sha512-ue6uzk04pRJCJIaU1xKAW7Fx4TJx5n5Dwtycm0H94msj5HpJOfDKPoO9+kbywZywWP7n+eNnzNl/6lMjCSfO4g==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.130.0",
+        "@aws-sdk/client-sts": "3.131.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
         "@aws-sdk/eventstream-serde-browser": "3.127.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.127.0",
         "@aws-sdk/eventstream-serde-node": "3.127.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-blob-browser": "3.127.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/hash-stream-node": "3.127.0",
@@ -238,7 +238,7 @@
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.127.0",
         "@aws-sdk/util-defaults-mode-node": "3.130.0",
-        "@aws-sdk/util-stream-browser": "3.129.0",
+        "@aws-sdk/util-stream-browser": "3.131.0",
         "@aws-sdk/util-stream-node": "3.129.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
@@ -255,14 +255,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.130.0.tgz",
-      "integrity": "sha512-Row4I85LeLA3GDrF+rs6mATDDsD+eljG/HQTQb+ohPd2aeaGyLvsAwDW9RQytadNOSf6TYJrV2fqiiAwa/m7NA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -296,15 +296,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.130.0.tgz",
-      "integrity": "sha512-OlDmQvMHEftXOoeg0OqnPzCfFbWPZLotON4ZQSTIy+rQXu+PNvEBML5JYKnVXVx0p8IMt5OzuWnGTJLVfIixvQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -385,13 +385,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.130.0.tgz",
-      "integrity": "sha512-xix0SbDJAacpq4gBpwaW24BsX5IfDpVR500nzLHkqc+/Q3OF3/F8c1iL+ZzHVZhxln+56582auUVehUBFKV4CA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -403,15 +403,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.130.0.tgz",
-      "integrity": "sha512-lXrpfNCSn6OrZXGB4F2VFU8xq0SOIOIBc6vpEywsqHZvE2r3Jq2pDMD1+2OGjMZDaRTTwD5D7GtJPlaiBNO+kw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.130.0",
+        "@aws-sdk/credential-provider-ini": "3.131.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -437,11 +437,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.130.0.tgz",
-      "integrity": "sha512-BeVpOYmo5ISKwHizr9gH65jIzkaOtpO/cvNHLYRCdR457zpHJfOzi3OBryw9AiFg0hfagjnIo9rlxQrQs0QnFg==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.130.0",
+        "@aws-sdk/client-sso": "3.131.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.127.0.tgz",
-      "integrity": "sha512-Z+KGGcG9pBdOmFEI+YJZFPlM55h5IaBuvcUdGjXlqWDaGHRtnsm91PrUxTvqd2XJkgfsaNrzbhAy7+UyAGmBog==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -1126,11 +1126,11 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.129.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.129.0.tgz",
-      "integrity": "sha512-Zo9oZuRsR1pcxvpES7uK08php9Dkw/ut8IBvJHzUs+J3o9TziyQRiRFegiQBs9Q4a6z7hyoMwUeoo+MMFulNVQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.131.0.tgz",
+      "integrity": "sha512-1YFbBPDu+elIgp8z1woUfT7zM+2PAvgJiw6ljDBuAlJzsP5xMhwk0X9e+8aQ+Qe4XftA0e7y/PH0gqvjNgCx2A==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-hex-encoding": "3.109.0",
@@ -1362,7 +1362,7 @@
     "node_modules/@opentdf/client": {
       "version": "0.2.2",
       "resolved": "file:../opentdf-client-0.2.2.tgz",
-      "integrity": "sha512-RFqzm1HC0jJZz4pjPuFCLf6LPzdgNT+6ABvKSqqSx0O/axBFUQL3W6IXrZGTFRafKaz+TUVZMpfBqEfVrEIhEA==",
+      "integrity": "sha512-LqrD1v21mKSHt1qg/iLoZocafKe/1R9TIgcuWCNaPFe47PirpNBFggbe8MXIOy1KqiyoA3PP6uN1EvGU9nQmlQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.75.0",
@@ -1373,7 +1373,6 @@
         "jose": "^4.8.1",
         "jsonschema": "^1.4.0",
         "node-forge": "^1.3.1",
-        "ua-parser-js": "^1.0.2",
         "uuid": "~8.3.2",
         "web-streams-node": "^0.4.0"
       }
@@ -4265,24 +4264,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4656,20 +4637,20 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.130.0.tgz",
-      "integrity": "sha512-JA/3T8U/fZZZvrpLIdv4HDoL7JrbvW5SERe3ni6UtqlW6y9jlfS824KmBnKSzVdSwdn6qzl6k9Z/xN2hDa+Qdw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.131.0.tgz",
+      "integrity": "sha512-ue6uzk04pRJCJIaU1xKAW7Fx4TJx5n5Dwtycm0H94msj5HpJOfDKPoO9+kbywZywWP7n+eNnzNl/6lMjCSfO4g==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.130.0",
+        "@aws-sdk/client-sts": "3.131.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
         "@aws-sdk/eventstream-serde-browser": "3.127.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.127.0",
         "@aws-sdk/eventstream-serde-node": "3.127.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-blob-browser": "3.127.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/hash-stream-node": "3.127.0",
@@ -4703,7 +4684,7 @@
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.127.0",
         "@aws-sdk/util-defaults-mode-node": "3.130.0",
-        "@aws-sdk/util-stream-browser": "3.129.0",
+        "@aws-sdk/util-stream-browser": "3.131.0",
         "@aws-sdk/util-stream-node": "3.129.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
@@ -4717,14 +4698,14 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.130.0.tgz",
-      "integrity": "sha512-Row4I85LeLA3GDrF+rs6mATDDsD+eljG/HQTQb+ohPd2aeaGyLvsAwDW9RQytadNOSf6TYJrV2fqiiAwa/m7NA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -4755,15 +4736,15 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.130.0.tgz",
-      "integrity": "sha512-OlDmQvMHEftXOoeg0OqnPzCfFbWPZLotON4ZQSTIy+rQXu+PNvEBML5JYKnVXVx0p8IMt5OzuWnGTJLVfIixvQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -4832,13 +4813,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.130.0.tgz",
-      "integrity": "sha512-xix0SbDJAacpq4gBpwaW24BsX5IfDpVR500nzLHkqc+/Q3OF3/F8c1iL+ZzHVZhxln+56582auUVehUBFKV4CA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -4847,15 +4828,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.130.0.tgz",
-      "integrity": "sha512-lXrpfNCSn6OrZXGB4F2VFU8xq0SOIOIBc6vpEywsqHZvE2r3Jq2pDMD1+2OGjMZDaRTTwD5D7GtJPlaiBNO+kw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.130.0",
+        "@aws-sdk/credential-provider-ini": "3.131.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -4875,11 +4856,11 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.130.0.tgz",
-      "integrity": "sha512-BeVpOYmo5ISKwHizr9gH65jIzkaOtpO/cvNHLYRCdR457zpHJfOzi3OBryw9AiFg0hfagjnIo9rlxQrQs0QnFg==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.130.0",
+        "@aws-sdk/client-sso": "3.131.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -4947,9 +4928,9 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.127.0.tgz",
-      "integrity": "sha512-Z+KGGcG9pBdOmFEI+YJZFPlM55h5IaBuvcUdGjXlqWDaGHRtnsm91PrUxTvqd2XJkgfsaNrzbhAy7+UyAGmBog==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -5415,11 +5396,11 @@
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.129.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.129.0.tgz",
-      "integrity": "sha512-Zo9oZuRsR1pcxvpES7uK08php9Dkw/ut8IBvJHzUs+J3o9TziyQRiRFegiQBs9Q4a6z7hyoMwUeoo+MMFulNVQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.131.0.tgz",
+      "integrity": "sha512-1YFbBPDu+elIgp8z1woUfT7zM+2PAvgJiw6ljDBuAlJzsP5xMhwk0X9e+8aQ+Qe4XftA0e7y/PH0gqvjNgCx2A==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-hex-encoding": "3.109.0",
@@ -5603,7 +5584,7 @@
     },
     "@opentdf/client": {
       "version": "file:../opentdf-client-0.2.2.tgz",
-      "integrity": "sha512-RFqzm1HC0jJZz4pjPuFCLf6LPzdgNT+6ABvKSqqSx0O/axBFUQL3W6IXrZGTFRafKaz+TUVZMpfBqEfVrEIhEA==",
+      "integrity": "sha512-LqrD1v21mKSHt1qg/iLoZocafKe/1R9TIgcuWCNaPFe47PirpNBFggbe8MXIOy1KqiyoA3PP6uN1EvGU9nQmlQ==",
       "requires": {
         "@aws-sdk/client-s3": "^3.75.0",
         "axios": "^0.26.1",
@@ -5613,7 +5594,6 @@
         "jose": "^4.8.1",
         "jsonschema": "^1.4.0",
         "node-forge": "^1.3.1",
-        "ua-parser-js": "^1.0.2",
         "uuid": "~8.3.2",
         "web-streams-node": "^0.4.0"
       }
@@ -7716,11 +7696,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/lib/lic-checker-config.yaml
+++ b/lib/lic-checker-config.yaml
@@ -5,4 +5,3 @@ blacklisted-licenses:
 whitelisted-modules:
   - jszip@3.7.1
   - node-forge@1.2.1
-  - ua-parser-js@0.7.9

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -17,7 +17,6 @@
         "jose": "^4.8.1",
         "jsonschema": "^1.4.0",
         "node-forge": "^1.3.1",
-        "ua-parser-js": "^1.0.2",
         "uuid": "~8.3.2",
         "web-streams-node": "^0.4.0"
       },
@@ -14089,24 +14088,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/umd": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
@@ -25756,11 +25737,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
     },
     "umd": {
       "version": "3.0.3",

--- a/lib/package.json
+++ b/lib/package.json
@@ -63,7 +63,6 @@
     "jose": "^4.8.1",
     "jsonschema": "^1.4.0",
     "node-forge": "^1.3.1",
-    "ua-parser-js": "^1.0.2",
     "uuid": "~8.3.2",
     "web-streams-node": "^0.4.0"
   },

--- a/sample-web-app/package-lock.json
+++ b/sample-web-app/package-lock.json
@@ -206,20 +206,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.130.0.tgz",
-      "integrity": "sha512-JA/3T8U/fZZZvrpLIdv4HDoL7JrbvW5SERe3ni6UtqlW6y9jlfS824KmBnKSzVdSwdn6qzl6k9Z/xN2hDa+Qdw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.131.0.tgz",
+      "integrity": "sha512-ue6uzk04pRJCJIaU1xKAW7Fx4TJx5n5Dwtycm0H94msj5HpJOfDKPoO9+kbywZywWP7n+eNnzNl/6lMjCSfO4g==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.130.0",
+        "@aws-sdk/client-sts": "3.131.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
         "@aws-sdk/eventstream-serde-browser": "3.127.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.127.0",
         "@aws-sdk/eventstream-serde-node": "3.127.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-blob-browser": "3.127.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/hash-stream-node": "3.127.0",
@@ -253,7 +253,7 @@
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.127.0",
         "@aws-sdk/util-defaults-mode-node": "3.130.0",
-        "@aws-sdk/util-stream-browser": "3.129.0",
+        "@aws-sdk/util-stream-browser": "3.131.0",
         "@aws-sdk/util-stream-node": "3.129.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
@@ -270,14 +270,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.130.0.tgz",
-      "integrity": "sha512-Row4I85LeLA3GDrF+rs6mATDDsD+eljG/HQTQb+ohPd2aeaGyLvsAwDW9RQytadNOSf6TYJrV2fqiiAwa/m7NA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -311,15 +311,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.130.0.tgz",
-      "integrity": "sha512-OlDmQvMHEftXOoeg0OqnPzCfFbWPZLotON4ZQSTIy+rQXu+PNvEBML5JYKnVXVx0p8IMt5OzuWnGTJLVfIixvQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -400,13 +400,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.130.0.tgz",
-      "integrity": "sha512-xix0SbDJAacpq4gBpwaW24BsX5IfDpVR500nzLHkqc+/Q3OF3/F8c1iL+ZzHVZhxln+56582auUVehUBFKV4CA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -418,15 +418,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.130.0.tgz",
-      "integrity": "sha512-lXrpfNCSn6OrZXGB4F2VFU8xq0SOIOIBc6vpEywsqHZvE2r3Jq2pDMD1+2OGjMZDaRTTwD5D7GtJPlaiBNO+kw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.130.0",
+        "@aws-sdk/credential-provider-ini": "3.131.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -452,11 +452,11 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.130.0.tgz",
-      "integrity": "sha512-BeVpOYmo5ISKwHizr9gH65jIzkaOtpO/cvNHLYRCdR457zpHJfOzi3OBryw9AiFg0hfagjnIo9rlxQrQs0QnFg==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.130.0",
+        "@aws-sdk/client-sso": "3.131.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.127.0.tgz",
-      "integrity": "sha512-Z+KGGcG9pBdOmFEI+YJZFPlM55h5IaBuvcUdGjXlqWDaGHRtnsm91PrUxTvqd2XJkgfsaNrzbhAy7+UyAGmBog==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -1141,11 +1141,11 @@
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.129.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.129.0.tgz",
-      "integrity": "sha512-Zo9oZuRsR1pcxvpES7uK08php9Dkw/ut8IBvJHzUs+J3o9TziyQRiRFegiQBs9Q4a6z7hyoMwUeoo+MMFulNVQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.131.0.tgz",
+      "integrity": "sha512-1YFbBPDu+elIgp8z1woUfT7zM+2PAvgJiw6ljDBuAlJzsP5xMhwk0X9e+8aQ+Qe4XftA0e7y/PH0gqvjNgCx2A==",
       "dependencies": {
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-hex-encoding": "3.109.0",
@@ -1960,7 +1960,7 @@
     "node_modules/@opentdf/client": {
       "version": "0.2.2",
       "resolved": "file:../opentdf-client-0.2.2.tgz",
-      "integrity": "sha512-RFqzm1HC0jJZz4pjPuFCLf6LPzdgNT+6ABvKSqqSx0O/axBFUQL3W6IXrZGTFRafKaz+TUVZMpfBqEfVrEIhEA==",
+      "integrity": "sha512-LqrD1v21mKSHt1qg/iLoZocafKe/1R9TIgcuWCNaPFe47PirpNBFggbe8MXIOy1KqiyoA3PP6uN1EvGU9nQmlQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.75.0",
@@ -1971,7 +1971,6 @@
         "jose": "^4.8.1",
         "jsonschema": "^1.4.0",
         "node-forge": "^1.3.1",
-        "ua-parser-js": "^1.0.2",
         "uuid": "~8.3.2",
         "web-streams-node": "^0.4.0"
       }
@@ -9984,24 +9983,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -10611,20 +10592,20 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.130.0.tgz",
-      "integrity": "sha512-JA/3T8U/fZZZvrpLIdv4HDoL7JrbvW5SERe3ni6UtqlW6y9jlfS824KmBnKSzVdSwdn6qzl6k9Z/xN2hDa+Qdw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.131.0.tgz",
+      "integrity": "sha512-ue6uzk04pRJCJIaU1xKAW7Fx4TJx5n5Dwtycm0H94msj5HpJOfDKPoO9+kbywZywWP7n+eNnzNl/6lMjCSfO4g==",
       "requires": {
         "@aws-crypto/sha1-browser": "2.0.0",
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.130.0",
+        "@aws-sdk/client-sts": "3.131.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
         "@aws-sdk/eventstream-serde-browser": "3.127.0",
         "@aws-sdk/eventstream-serde-config-resolver": "3.127.0",
         "@aws-sdk/eventstream-serde-node": "3.127.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-blob-browser": "3.127.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/hash-stream-node": "3.127.0",
@@ -10658,7 +10639,7 @@
         "@aws-sdk/util-body-length-node": "3.55.0",
         "@aws-sdk/util-defaults-mode-browser": "3.127.0",
         "@aws-sdk/util-defaults-mode-node": "3.130.0",
-        "@aws-sdk/util-stream-browser": "3.129.0",
+        "@aws-sdk/util-stream-browser": "3.131.0",
         "@aws-sdk/util-stream-node": "3.129.0",
         "@aws-sdk/util-user-agent-browser": "3.127.0",
         "@aws-sdk/util-user-agent-node": "3.127.0",
@@ -10672,14 +10653,14 @@
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.130.0.tgz",
-      "integrity": "sha512-Row4I85LeLA3GDrF+rs6mATDDsD+eljG/HQTQb+ohPd2aeaGyLvsAwDW9RQytadNOSf6TYJrV2fqiiAwa/m7NA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+      "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -10710,15 +10691,15 @@
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.130.0.tgz",
-      "integrity": "sha512-OlDmQvMHEftXOoeg0OqnPzCfFbWPZLotON4ZQSTIy+rQXu+PNvEBML5JYKnVXVx0p8IMt5OzuWnGTJLVfIixvQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+      "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
         "@aws-sdk/config-resolver": "3.130.0",
-        "@aws-sdk/credential-provider-node": "3.130.0",
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/hash-node": "3.127.0",
         "@aws-sdk/invalid-dependency": "3.127.0",
         "@aws-sdk/middleware-content-length": "3.127.0",
@@ -10787,13 +10768,13 @@
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.130.0.tgz",
-      "integrity": "sha512-xix0SbDJAacpq4gBpwaW24BsX5IfDpVR500nzLHkqc+/Q3OF3/F8c1iL+ZzHVZhxln+56582auUVehUBFKV4CA==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+      "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -10802,15 +10783,15 @@
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.130.0.tgz",
-      "integrity": "sha512-lXrpfNCSn6OrZXGB4F2VFU8xq0SOIOIBc6vpEywsqHZvE2r3Jq2pDMD1+2OGjMZDaRTTwD5D7GtJPlaiBNO+kw==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+      "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.127.0",
         "@aws-sdk/credential-provider-imds": "3.127.0",
-        "@aws-sdk/credential-provider-ini": "3.130.0",
+        "@aws-sdk/credential-provider-ini": "3.131.0",
         "@aws-sdk/credential-provider-process": "3.127.0",
-        "@aws-sdk/credential-provider-sso": "3.130.0",
+        "@aws-sdk/credential-provider-sso": "3.131.0",
         "@aws-sdk/credential-provider-web-identity": "3.127.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
@@ -10830,11 +10811,11 @@
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.130.0.tgz",
-      "integrity": "sha512-BeVpOYmo5ISKwHizr9gH65jIzkaOtpO/cvNHLYRCdR457zpHJfOzi3OBryw9AiFg0hfagjnIo9rlxQrQs0QnFg==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+      "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
       "requires": {
-        "@aws-sdk/client-sso": "3.130.0",
+        "@aws-sdk/client-sso": "3.131.0",
         "@aws-sdk/property-provider": "3.127.0",
         "@aws-sdk/shared-ini-file-loader": "3.127.0",
         "@aws-sdk/types": "3.127.0",
@@ -10902,9 +10883,9 @@
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.127.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.127.0.tgz",
-      "integrity": "sha512-Z+KGGcG9pBdOmFEI+YJZFPlM55h5IaBuvcUdGjXlqWDaGHRtnsm91PrUxTvqd2XJkgfsaNrzbhAy7+UyAGmBog==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+      "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
       "requires": {
         "@aws-sdk/protocol-http": "3.127.0",
         "@aws-sdk/querystring-builder": "3.127.0",
@@ -11370,11 +11351,11 @@
       }
     },
     "@aws-sdk/util-stream-browser": {
-      "version": "3.129.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.129.0.tgz",
-      "integrity": "sha512-Zo9oZuRsR1pcxvpES7uK08php9Dkw/ut8IBvJHzUs+J3o9TziyQRiRFegiQBs9Q4a6z7hyoMwUeoo+MMFulNVQ==",
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.131.0.tgz",
+      "integrity": "sha512-1YFbBPDu+elIgp8z1woUfT7zM+2PAvgJiw6ljDBuAlJzsP5xMhwk0X9e+8aQ+Qe4XftA0e7y/PH0gqvjNgCx2A==",
       "requires": {
-        "@aws-sdk/fetch-http-handler": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
         "@aws-sdk/types": "3.127.0",
         "@aws-sdk/util-base64-browser": "3.109.0",
         "@aws-sdk/util-hex-encoding": "3.109.0",
@@ -12015,7 +11996,7 @@
     },
     "@opentdf/client": {
       "version": "file:../opentdf-client-0.2.2.tgz",
-      "integrity": "sha512-RFqzm1HC0jJZz4pjPuFCLf6LPzdgNT+6ABvKSqqSx0O/axBFUQL3W6IXrZGTFRafKaz+TUVZMpfBqEfVrEIhEA==",
+      "integrity": "sha512-LqrD1v21mKSHt1qg/iLoZocafKe/1R9TIgcuWCNaPFe47PirpNBFggbe8MXIOy1KqiyoA3PP6uN1EvGU9nQmlQ==",
       "requires": {
         "@aws-sdk/client-s3": "^3.75.0",
         "axios": "^0.26.1",
@@ -12025,7 +12006,6 @@
         "jose": "^4.8.1",
         "jsonschema": "^1.4.0",
         "node-forge": "^1.3.1",
-        "ua-parser-js": "^1.0.2",
         "uuid": "~8.3.2",
         "web-streams-node": "^0.4.0"
       }
@@ -18171,11 +18151,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
-      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
     },
     "unbzip2-stream": {
       "version": "1.4.3",


### PR DESCRIPTION
this was used to decide when to use sjcl instead of safari but we no longer support older (2017 & earlier) safaris