### PR TITLE
🚀 Publish fixes & polish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -172,14 +172,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # To publish from a release or feature branch, remove the ref == condition below
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
+      || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
+    outputs:
+      FULL_VERSION: ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
+      DIST_TAG: ${{ steps.guess-build-metadata.outputs.DIST_TAG }}
+      TARGET_VERSION: ${{ steps.check-version.outputs.TARGET_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
           registry-url: https://npm.pkg.github.com
-      - run: |-
+      - name: Check version number is same between tag, library, and/or release
+        id: check-version
+        run: |-
           if [[ ${{ github.ref }} = refs/heads/release/* ]]; then
             scripts/check-version-is.sh "${GITHUB_REF##*release/}"
           elif [[ ${{ github.ref }} = refs/tags/v* ]]; then
@@ -187,11 +196,17 @@ jobs:
           else
             scripts/check-version-is.sh
           fi
+      - name: Check version number is same between tag, library, and/or release
+        id: guess-build-metadata
+        run: |-
+          echo "::set-output name=FULL_VERSION::$(.github/workflows/gh-semver.sh)"
+          echo "::set-output name=DIST_TAG::$(.github/workflows/guess-dist-tag.sh)"
       - run: make test
       - run: make doc
-      - run:
-          .github/workflows/publish-to.sh $(.github/workflows/gh-semver.sh)
-          $(.github/workflows/guess-dist-tag.sh)
+      - run: echo "::notice file=lib/package.json::Will be published to GitHub Packages as $(.github/workflows/guess-dist-tag.sh) with version=[$(.github/workflows/guess-dist-tag.sh)]"
+      - run: >-
+          .github/workflows/publish-to.sh ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
+          ${{ steps.guess-build-metadata.outputs.FULL_VERSION }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: trigger xtest
@@ -207,28 +222,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: npmjs
+    needs: deliver-ghp
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
       || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
       || (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/'))
-    needs: deliver-ghp
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: |-
-          if [[ ${{ github.ref }} = refs/heads/release/* ]]; then
-            scripts/check-version-is.sh "${GITHUB_REF##*release/}"
-          elif [[ ${{ github.ref }} = refs/tags/v* ]]; then
-            scripts/check-version-is.sh "${GITHUB_REF_NAME#v}"
-          else
-            scripts/check-version-is.sh
-          fi
-      - run: make test
-      - run:
-          .github/workflows/publish-to.sh $(.github/workflows/gh-semver.sh)
-          $(.github/workflows/guess-dist-tag.sh)
+      - run: >-
+          .github/workflows/publish-to.sh ${{ needs.deliver-ghp.outputs.FULL_VERSION }}
+          ${{ needs.deliver-ghp.outputs.FULL_VERSION }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/gh-semver.sh
+++ b/.github/workflows/gh-semver.sh
@@ -3,7 +3,7 @@
 # git state and 'target' semver found in its package.
 #
 # Examples:
-# 
+#
 # Main branches build beta builds:
 # ```
 #    package.version = 1.2.3
@@ -14,7 +14,7 @@
 #    ----
 #    1.2.3-beta.256+bad.decaf
 # ```
-# 
+#
 # Release branches build rc builds:
 # ```
 #    package.version = 1.2.3
@@ -25,7 +25,7 @@
 #    ----
 #    1.2.3-rc.256+bad.decaf
 # ```
-# 
+#
 # Tags go to release:
 # ```
 #    package.version = 1.2.3
@@ -36,7 +36,7 @@
 #    1.2.3
 # ```
 #
-# 
+#
 set -euo pipefail
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/.github/workflows/publish-to.sh
+++ b/.github/workflows/publish-to.sh
@@ -17,4 +17,8 @@ cd ../cli
 npm --no-git-tag-version --allow-same-version version "$v" --tag "$t"
 npm uninstall "@opentdf/client"
 npm install "@opentdf/client@$v"
-npm publish
+npm publish --access public
+
+if [[ "$GITHUB_STEP_SUMMARY" ]]; then
+  echo "### Published ${v}" >>$GITHUB_STEP_SUMMARY
+fi

--- a/scripts/check-version-is.sh
+++ b/scripts/check-version-is.sh
@@ -8,14 +8,18 @@ lib_version="$(cd lib && node -p "require('./package.json').version")"
 expected_version="${1:-$lib_version}"
 
 if ! grep -Fxq "version=${expected_version}" "Makefile"; then
-  echo "Makefile missing version line [version=${expected_version}]"
+  echo "::error file=Makefile::Makefile missing version line [version=${expected_version}]"
   exit 1
 fi
 
 for x in lib cli web-app; do
   sub_version="$(cd $x && node -p "require('./package.json').version")"
   if [[ $expected_version != "$sub_version" ]]; then
-    echo "${x} has incorrect version  [${sub_version}], expected [${expected_version}]"
+    echo "::error file=${x}/package.json::Incorrect version  [${sub_version}], expected [${expected_version}]"
     exit 1
   fi
 done
+
+if [[ "${GITHUB_ACTION}" ]]; then
+  echo "::set-output name=TARGET_VERSION::$expected_version"
+fi


### PR DESCRIPTION
- Annotate the workflow with the generated semver and tag
- Set access level to public, fixing issue with 'first publish' failing to npm (probably)
- Since npm publish depends on GHPR publish, do that first always, and share the knowledge between them