### PR TITLE
🐛 Fix mixing FileClient 'source' and params

### DIFF
--- a/lib/tdf3/src/client/builders.ts
+++ b/lib/tdf3/src/client/builders.ts
@@ -169,7 +169,7 @@ class EncryptParamsBuilder {
       rcaSource: false,
     }
   ) {
-    this._params = structuredClone(params);
+    this._params = { ...params };
   }
 
   setContentLength(contentLength: number) {

--- a/lib/tdf3/src/client/builders.ts
+++ b/lib/tdf3/src/client/builders.ts
@@ -155,8 +155,8 @@ function freeze<Type>(obj: Type): Readonly<Type> {
 class EncryptParamsBuilder {
   private _params: Partial<EncryptParams>;
 
-  constructor() {
-    this._params = {
+  constructor(
+    params: Partial<EncryptParams> = {
       scope: {
         dissem: [],
         attributes: [],
@@ -167,7 +167,9 @@ class EncryptParamsBuilder {
       windowSize: DEFAULT_SEGMENT_SIZE,
       asHtml: false,
       rcaSource: false,
-    };
+    }
+  ) {
+    this._params = structuredClone(params);
   }
 
   setContentLength(contentLength: number) {
@@ -620,9 +622,9 @@ export type DecryptParams = {
 class DecryptParamsBuilder {
   private _params: DecryptParams;
 
-  constructor() {
+  constructor(to_copy: DecryptParams = { source: null }) {
     this._params = {
-      source: null,
+      ...to_copy,
     };
   }
 

--- a/lib/tdf3/test/unit/FileClient.spec.ts
+++ b/lib/tdf3/test/unit/FileClient.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from 'chai';
+// TODO Validate http urls resolve to fetch requests
+// import fs from 'node:fs';
+// import { createServer, Server } from 'node:http';
+// import send from 'send';
+import { createSandbox, type SinonSpy, type SinonSandbox } from 'sinon';
+
+import { FileClient } from '../../src/FileClient';
+import { Client as ClientTdf3 } from '../../src/client/index';
+import { EncryptParamsBuilder } from '../../src/client/builders';
+
+describe('FileClient', () => {
+  let box: SinonSandbox;
+  beforeEach(() => {
+    box = createSandbox();
+  });
+  afterEach(() => {
+    box.restore();
+  });
+
+  let client: ClientTdf3;
+  let encrypt: SinonSpy;
+  let decrypt: SinonSpy;
+  beforeEach(() => {
+    decrypt = box.fake();
+    encrypt = box.fake();
+    client = { decrypt, encrypt } as unknown as ClientTdf3;
+  });
+  describe('encrypt', () => {
+    it('file source bare', async () => {
+      const fileClient = new FileClient(client);
+      await fileClient.encrypt('README.md');
+      expect(encrypt.callCount).to.equal(1);
+      const params = encrypt.args[0][0];
+      expect(params).to.contain({ offline: true });
+      expect(params.source).to.be.an.instanceOf(ReadableStream);
+    });
+    it('file source url', async () => {
+      const fileClient = new FileClient(client);
+      await fileClient.encrypt('file://./README.md');
+      expect(encrypt.callCount).to.equal(1);
+      const params = encrypt.args[0][0];
+      expect(params).to.contain({ offline: true });
+      expect(params.source).to.be.an.instanceOf(ReadableStream);
+    });
+    it('dissems', async () => {
+      const fileClient = new FileClient(client);
+      await fileClient.encrypt('README.md', ['a', 'b']);
+      expect(encrypt.callCount).to.equal(1);
+      const params = encrypt.args[0][0];
+      expect(params).to.deep.include({ scope: { attributes: [], dissem: ['a', 'b'] } });
+    });
+    it('attributes', async () => {
+      const fileClient = new FileClient(client);
+      await fileClient.encrypt(
+        'README.md',
+        [],
+        new EncryptParamsBuilder()
+          .withAttributes([{ attribute: 'https://hay.co/attr/a/value/1' }])
+          .build()
+      );
+      expect(encrypt.callCount).to.equal(1);
+      const params = encrypt.args[0][0];
+      expect(params).to.deep.include({
+        scope: { attributes: [{ attribute: 'https://hay.co/attr/a/value/1' }], dissem: [] },
+      });
+    });
+  });
+
+  describe('decrypt', () => {
+    it('file source bare', async () => {
+      const fileClient = new FileClient(client);
+      const location = 'README.md';
+      await fileClient.decrypt(location);
+      expect(decrypt.callCount).to.equal(1);
+      const params = decrypt.args[0][0];
+      console.log(params);
+      expect(params).to.deep.include({ source: { location, type: 'file-node' } });
+    });
+    it('file source url', async () => {
+      const fileClient = new FileClient(client);
+      const location = 'file://./README.md';
+      await fileClient.decrypt(location);
+      expect(decrypt.callCount).to.equal(1);
+      const params = decrypt.args[0][0];
+      console.log(params);
+      expect(params).to.deep.include({ source: { location, type: 'file-node' } });
+    });
+  });
+});


### PR DESCRIPTION
Previously, the source and params options were exclusive. With this fix, they are properly merged (again)