### PR TITLE
🚨 Fixes a few github action warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Git clone backend
         run: |
           git clone https://github.com/opentdf/opentdf.git
-      - uses: yokawasa/action-setup-kube-tools@v0.9.0
+      - uses: yokawasa/action-setup-kube-tools@v0.9.2
         with:
           setup-tools: |
             kubectl
@@ -210,8 +210,8 @@ jobs:
       - name: Check version number is same between tag, library, and/or release
         id: guess-build-metadata
         run: |-
-          echo "::set-output name=FULL_VERSION::$(.github/workflows/gh-semver.sh)"
-          echo "::set-output name=DIST_TAG::$(.github/workflows/guess-dist-tag.sh)"
+          echo "FULL_VERSION=$(.github/workflows/gh-semver.sh)" >> $GITHUB_OUTPUT
+          echo "DIST_TAG=$(.github/workflows/guess-dist-tag.sh)" >> $GITHUB_OUTPUT
       - run: make test
       - run: make doc
       - run: echo "::notice file=lib/package.json::Will be published to [GitHub Packages](https://github.com/opentdf/client-web/pkgs/npm/client) as ${{ steps.guess-build-metadata.outputs.DIST_TAG }} with version=[${{ steps.guess-build-metadata.outputs.FULL_VERSION }}]"

--- a/scripts/check-version-is.sh
+++ b/scripts/check-version-is.sh
@@ -21,5 +21,5 @@ for x in lib cli cli-commonjs web-app; do
 done
 
 if [[ "${GITHUB_ACTION}" ]]; then
-  echo "::set-output name=TARGET_VERSION::$expected_version"
+  echo "TARGET_VERSION=$expected_version" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
- Remove use of `::set-output` in favor of new `GITHUB_OUTPUT` environment file
- Update to latest kube-tools action which also has this problem