### PR TITLE
🔨 Require `make format` on fork PRs

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,7 +13,7 @@ jobs:
           cache-dependency-path: './lib/package-lock.json'
       - run: make format
       - name: ignore package-lock changes
-        run: git checkout -- {cli,web-app}/package-lock.json
+        run: git restore "*/package-lock.json"
       - name: Check that files have been formatted before PR submission
         run: git diff-files --quiet --ignore-submodules
         if: ${{ github.event.pull_request.head.repo.full_name != 'opentdf/client-web' }}

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -14,8 +14,12 @@ jobs:
       - run: make format
       - name: ignore package-lock changes
         run: git checkout -- {cli,web-app}/package-lock.json
+      - name: Check that files have been formatted before PR submission
+        run: git diff-files --quiet --ignore-submodules
+        if: ${{ github.event.pull_request.head.repo.full_name != 'opentdf/client-web' }}
       - name: Commit changes
         id: auto-commit
+        if: ${{ github.event.pull_request.head.repo.full_name == 'opentdf/client-web' }}
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: |-

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -14,6 +14,8 @@ jobs:
       - run: make format
       - name: ignore package-lock changes
         run: git restore "*/package-lock.json"
+      - run: git diff
+      - run: git diff-files --ignore-submodules
       - name: Check that files have been formatted before PR submission
         run: git diff-files --quiet --ignore-submodules
         if: ${{ github.event.pull_request.head.repo.full_name != 'opentdf/client-web' }}


### PR DESCRIPTION
The auto-commit workflow doesn't work on untrusted forks, and probably isn't worth the trouble to fix. Let's see how this works for contributors