### PR TITLE
🐛 Fix sed and grep errors and x-plat problems

### DIFF
--- a/.github/workflows/publish-to.sh
+++ b/.github/workflows/publish-to.sh
@@ -7,7 +7,13 @@ v="${1%%+*}"
 t="${2}"
 
 cd lib
-sed -i '' "s/export const version = '[^']\{1,\}';\$/export const version = \'${v}\';/" {,tdf3/}src/version.ts
+for f in {,tdf3/}src/version.ts; do
+  if ! sed "s/export const version = \'[^']\{1,\}\';\$/export const version = \'${v}\';/" $f >${f}.tmp; then
+    echo "Failed to insert version [${v}] into file [$f]"
+    exit 1
+  fi
+  mv "${f}.tmp" "${f}"
+done
 npm --no-git-tag-version --allow-same-version version "$v" --tag "$t"
 npm publish --access public
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -35,17 +35,23 @@ for x in "${packages[@]:1}"; do
   )
 done
 
-if ! sed -i '' "s/version=${old_version}/version=${new_version}/" "Makefile"; then
+# multiplatform `sed -i`: https://unix.stackexchange.com/a/92907
+case $(sed --help 2>&1) in
+  *GNU*) sed_i () { sed -i "$@"; };;
+  *) sed_i () { sed -i '' "$@"; };;
+esac
+
+if ! sed_i "s/version=${old_version}/version=${new_version}/" "Makefile"; then
   echo "Unable to change version in makefile"
   exit 1
 fi
 
-if ! sed -i '' "s/export const version = '[^']\{1,\}';\$/export const version = \'${new_version}\';/" lib{,/tdf3}/src/version.ts; then
+if ! sed_i "s/export const version = '[^']\{1,\}';\$/export const version = \'${new_version}\';/" lib{,/tdf3}/src/version.ts; then
   echo "Unable to change version in version files"
   exit 1
 fi
 
-if ! sed -i '' "s/export const version = '[^']\{1,\}';\$/export const version = \'${new_version}\';/" lib{,/tdf3}/src/version.ts; then
+if ! sed_i "s/export const version = '[^']\{1,\}';\$/export const version = \'${new_version}\';/" lib{,/tdf3}/src/version.ts; then
   echo "Unable to change version in version files"
   exit 1
 fi

--- a/scripts/check-version-is.sh
+++ b/scripts/check-version-is.sh
@@ -7,19 +7,23 @@ lib_version="$(cd lib && node -p "require('./package.json').version")"
 
 expected_version="${1:-$lib_version}"
 
-if ! grep -Fxq "version=${expected_version}" "Makefile"; then
-  echo "::error file=Makefile::Makefile missing version line [version=${expected_version}]"
+if ! grep --fixed-strings --line-regexp --quiet "version=${expected_version}" "Makefile"; then
+  if grep --quiet "^version=" "Makefile"; then
+    echo "::error file=Makefile,line=$(sed -n  '/version/=' $f)::Incorrect version line, should be setting it to [${expected_version}]"
+  else
+    echo "::error file=Makefile::Makefile missing version line [version=${expected_version}]"
+  fi
   exit 1
 fi
 
 for f in lib{,/tdf3}/src/version.ts; do
-  if ! grep -Fxq "export const version = '${expected_version}'" "$f"; then
-    if grep -Fxq "export const version" "$f"; then
+  if ! grep --fixed-strings --line-regexp --quiet "export const version = '${expected_version}';" "$f"; then
+    if grep --quiet "^export const version" "$f"; then
       echo "::error file=$f,line=$(sed -n  '/export const version/=' $f)::Incorrect version line, should be setting it to [${expected_version}]"
-      exit 1
     else
       echo "::error file=$f::Missing version line [version=${expected_version}]"
     fi
+    exit 1
   fi
 done
 
@@ -31,6 +35,8 @@ for x in lib cli cli-commonjs web-app; do
   fi
 done
 
-if [[ "${GITHUB_ACTION}" ]]; then
+if [[ "${GITHUB_ACTION:-}" ]]; then
   echo "TARGET_VERSION=$expected_version" >> $GITHUB_OUTPUT
+else
+  echo "SUCCESS: TARGET_VERSION=$expected_version"
 fi


### PR DESCRIPTION
- sed -I is not in the posix standard, and has different properties, so either don't use it or work around it
- there was an error in the grep logic so I made it more straightforward and used the long versions of the arguments for clarity. IDK if they are all standard but the arguments were in the man pages on both macOS and ubuntu (latest)