### PR TITLE
🧽 Remove potential PII from 'cause' objects

### DIFF
--- a/lib/tdf3/src/errors.ts
+++ b/lib/tdf3/src/errors.ts
@@ -1,8 +1,25 @@
+function scrubCause(error?: Error, d?: number): { cause?: Error } {
+  if (!error || (d && d > 4)) {
+    return {};
+  }
+  if (!error.name) {
+    return {};
+  }
+  const cause = new Error(error.name, scrubCause(error.cause as Error, (d || 0) + 1));
+  if (error.message) {
+    cause.message = error.message;
+  }
+  if (error.stack) {
+    cause.stack = error.stack;
+  }
+  return { cause };
+}
+
 export class TdfError extends Error {
   override name = 'TdfError';
 
   constructor(message: string, cause?: Error) {
-    super(message, { cause });
+    super(message, scrubCause(cause));
     // Error is funny (only on ES5? So  guess just IE11 we have to worry about?)
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     // https://stackoverflow.com/questions/41102060/typescript-extending-error-class#comment70895020_41102306

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -516,7 +516,10 @@ class TDF extends EventEmitter {
           }
           return response.data;
         } catch (e) {
-          throw new KasUpsertError('Unable to perform upsert operation on the KAS', e);
+          throw new KasUpsertError(
+            `Unable to perform upsert operation on the KAS: [${e.name}: ${e.message}], response: [${e?.response?.body}]`,
+            e
+          );
         }
       })
     );
@@ -849,7 +852,10 @@ class TDF extends EventEmitter {
           this.emit('rewrap', metadata);
           return decryptedKeyBinary.asBuffer();
         } catch (e) {
-          throw new KasDecryptError('Unable to decrypt the response from KAS', e);
+          throw new KasDecryptError(
+            `Unable to decrypt the response from KAS: [${e.name}: ${e.message}], response: [${e?.response?.body}]`,
+            e
+          );
         }
       })
     );


### PR DESCRIPTION
still keep stack trace and messages, but removes 'data' and 'config' information from axios errors, most notably