### PR TITLE
🚧 FileSystem API in web-app

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -5554,9 +5554,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -18,6 +18,7 @@
         "@rollup/plugin-inject": "^5.0.3",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "@types/wicg-file-system-access": "^2020.9.5",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
         "@vitejs/plugin-react": "^3.0.1",
@@ -1442,9 +1443,9 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2313,6 +2314,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6638,9 +6645,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -7313,6 +7320,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -24,6 +24,7 @@
     "@rollup/plugin-inject": "^5.0.3",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
     "@vitejs/plugin-react": "^3.0.1",

--- a/web-app/tests/static-server.js
+++ b/web-app/tests/static-server.js
@@ -20,6 +20,7 @@ export async function serve(path, port) {
     if (req.headers?.origin) {
       res.setHeader('Access-Control-Allow-Headers', req.headers.origin);
     }
+    res.setHeader('Access-Control-Expose-Headers', 'Content-Length')
     const url = new URL(req.url, `http://${req.headers.host}`);
     const validNamePart = NodePath.basename(url.pathname);
     const allowedName = `/${validNamePart}`;

--- a/web-app/tests/tests/roundtrip.spec.ts
+++ b/web-app/tests/tests/roundtrip.spec.ts
@@ -49,6 +49,21 @@ const scenarios = {
   html: { encryptSelector: '#htmlEncrypt', decryptSelector: '#tdfDecrypt' },
 };
 
+
+
+test.beforeEach(async ({page}) => {
+  await page.addInitScript(() => {
+    window.showSaveFilePicker = async ({ suggestedName: string }) => [ 
+      {{
+        async createWriteable() {
+          return this._file;
+        }
+      }}
+     ];
+  });
+});
+
+
 for (const [name, { encryptSelector, decryptSelector }] of Object.entries(scenarios)) {
   test(name, async ({ page }) => {
     await authorize(page);


### PR DESCRIPTION
Replaces download link generation with FileSystemAccess API implementation of streaming downloads for tdf3 (and html wrapped, kinda) containers. Works fine for tdf files (not HTML wrapped) of arbitrary size.

HOWEVER: the showSaveFilePicker is unsupported by Playwright, so any CI implementation might have to mock the whole thing.