### PR TITLE
⚗️ Adds more test scenarios to web-app

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -1421,7 +1421,7 @@
     "node_modules/@opentdf/client": {
       "version": "0.4.0",
       "resolved": "file:../lib/opentdf-client-0.4.0.tgz",
-      "integrity": "sha512-46OzwYNeQP3hE2H/5m3i8W4Ltr2w4K6rrWLYbbD2Q/2//V5T3zC+PifUZXfaXnBBItmHBqOagNC5vz+smLn9PQ==",
+      "integrity": "sha512-7wlJTGgWHMlwiZGZvp9hjEQJmL0TdRiyc6gyWOOPTK3Wnv8ElnniBZA4qNQFdQ51P2Y7w+lCEqD56lB/XCCF/g==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/client-s3": "3.197.0",
@@ -5554,9 +5554,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -5764,7 +5764,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-0.4.0.tgz",
-      "integrity": "sha512-46OzwYNeQP3hE2H/5m3i8W4Ltr2w4K6rrWLYbbD2Q/2//V5T3zC+PifUZXfaXnBBItmHBqOagNC5vz+smLn9PQ==",
+      "integrity": "sha512-7wlJTGgWHMlwiZGZvp9hjEQJmL0TdRiyc6gyWOOPTK3Wnv8ElnniBZA4qNQFdQ51P2Y7w+lCEqD56lB/XCCF/g==",
       "requires": {
         "@aws-sdk/client-s3": "3.197.0",
         "axios": "^1.2.3",

--- a/lib/tdf3/src/client/BrowserTdfSteam.ts
+++ b/lib/tdf3/src/client/BrowserTdfSteam.ts
@@ -1,10 +1,19 @@
-import { DecoratedReadableStream } from './DecoratedReadableStream.js';
+import {
+  DecoratedReadableStream,
+  type DecoratedReadableStreamSinkOptions,
+} from './DecoratedReadableStream.js';
 import streamSaver from 'streamsaver';
 import { fileSave } from 'browser-fs-access';
 import { isFirefox } from '../../../src/utils.js';
 
 export class BrowserTdfStream extends DecoratedReadableStream {
-  override async toFile(filepath = 'download.tdf'): Promise<void> {
+  override async toFile(
+    filepath = 'download.tdf',
+    options?: BufferEncoding | DecoratedReadableStreamSinkOptions
+  ): Promise<void> {
+    if (options && typeof options === 'string') {
+      throw new Error('Unsupported Operation: Cannot set encoding in browser');
+    }
     if (isFirefox()) {
       await fileSave(new Response(this.stream), {
         fileName: filepath,
@@ -20,7 +29,7 @@ export class BrowserTdfStream extends DecoratedReadableStream {
     });
 
     if (WritableStream) {
-      return this.stream.pipeTo(fileStream);
+      return this.stream.pipeTo(fileStream, options);
     }
 
     // Write (pipe) manually

--- a/lib/tdf3/src/client/DecoratedReadableStream.ts
+++ b/lib/tdf3/src/client/DecoratedReadableStream.ts
@@ -18,6 +18,11 @@ export async function streamToBuffer(stream: ReadableStream<Uint8Array>): Promis
   return Buffer.from(accumulator);
 }
 
+export type DecoratedReadableStreamSinkOptions = {
+  encoding?: BufferEncoding;
+  signal?: AbortSignal;
+};
+
 export abstract class DecoratedReadableStream {
   KEK: null | string;
   algorithm: string;
@@ -160,5 +165,8 @@ export abstract class DecoratedReadableStream {
    * @param filepath The path of the local file to write plaintext to.
    * @param encoding The charset encoding to use. Defaults to utf-8.
    */
-  abstract toFile(filepath: string, encoding?: BufferEncoding): Promise<void>;
+  abstract toFile(
+    filepath: string,
+    options?: BufferEncoding | DecoratedReadableStreamSinkOptions
+  ): Promise<void>;
 }

--- a/lib/tdf3/src/client/NodeTdfStream.ts
+++ b/lib/tdf3/src/client/NodeTdfStream.ts
@@ -12,7 +12,7 @@ export class NodeTdfStream extends DecoratedReadableStream {
   ): Promise<void> {
     const encoding =
       (typeof options === 'string' && options) || (options && options.encoding) || 'utf-8';
-    const nodeStream = createWriteStream(filepath, { encoding, flags: 'w' });
+    const nodeStream = createWriteStream(filepath, { encoding, flags: 'w', highWaterMark: 1 });
     const writer = Writable.toWeb(nodeStream);
     await this.stream.pipeTo(writer);
   }

--- a/lib/tdf3/src/client/NodeTdfStream.ts
+++ b/lib/tdf3/src/client/NodeTdfStream.ts
@@ -1,24 +1,19 @@
 import { createWriteStream } from 'node:fs';
-import { DecoratedReadableStream } from './DecoratedReadableStream.js';
+import { Writable } from 'node:stream';
+import {
+  DecoratedReadableStream,
+  type DecoratedReadableStreamSinkOptions,
+} from './DecoratedReadableStream.js';
 
 export class NodeTdfStream extends DecoratedReadableStream {
-  override async toFile(filepath: string, encoding: BufferEncoding = 'utf-8'): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const file = createWriteStream(filepath, { encoding, flags: 'w', highWaterMark: 1 });
-      const reader = this.stream.getReader();
-      const pump = () =>
-        reader
-          .read()
-          .then((res) => {
-            if (res.done) {
-              file.end();
-              resolve();
-            } else {
-              file.write(res.value, encoding, pump);
-            }
-          })
-          .catch(reject);
-      pump();
-    });
+  override async toFile(
+    filepath: string,
+    options: BufferEncoding | DecoratedReadableStreamSinkOptions = 'utf-8'
+  ): Promise<void> {
+    const encoding =
+      (typeof options === 'string' && options) || (options && options.encoding) || 'utf-8';
+    const nodeStream = createWriteStream(filepath, { encoding, flags: 'w' });
+    const writer = Writable.toWeb(nodeStream);
+    await this.stream.pipeTo(writer);
   }
 }

--- a/lib/tests/mocha/perf.spec.js
+++ b/lib/tests/mocha/perf.spec.js
@@ -27,17 +27,19 @@ const baseDir = `${dirname}/temp/perf`;
 // For now the gigabyte one is commented out..
 const sizes = {
   // Takes ~ 5ms to create, 25ms to round trip on my computer
+  '1-KB': 10 ** 3,
   '1-KiB': 2 ** 10,
   // '10-KiB': 10 * 2 ** 10,
-  '100-KiB': 100 * 2 ** 10,
+  // '100-KiB': 100 * 2 ** 10,
   // Takes about 1s to create file, 5s to round trip on my computer
   // '1-MiB': 2 ** 20,
   // Takes about 400ms to create file, 1m to round trip on my computer
   // NOTE the timeout for a mocha test is currently set to 20s, so these
   // tests will not run with the current settings (30s timeout, 3 iterations)
   // '16-MiB': 16 * 2 ** 20,
+  '16-MB': 16 * 10 ** 6,
   // Takes about 1.5s to create file, 2m20s to round trip on my computer
-  // '64-MiB': 64 * 2 ** 20,
+  // '64-MiB': 64 * 2 ** 20 + 12342,
   // Takes about 3s to create file, 20s to round trip on my computer
   // '256-MiB': 256 * 2 ** 20,
   // Takes about 10s to create file, 1m to round trip on my computer.
@@ -328,8 +330,13 @@ describe('Local Correctness Tests', function () {
   for (const streamType of ['file-node', 'file-stream']) {
     for (const encType of cryptoTypes) {
       for (const decType of cryptoTypes) {
-        it(`Round trip ${streamType} ${encType}->${decType}`, async function () {
-          const { path, size } = plainFiles['1-KiB'];
+        it(`Round trip ${streamType} ${encType}->${decType} small`, async function () {
+          const { path, size } = plainFiles['1-KB'];
+          // TODO Update correctness trial to take crypto types
+          await correctnessTrial(path, streamType, size, 'correctness');
+        });
+        it(`Round trip ${streamType} ${encType}->${decType} BIG`, async function () {
+          const { path, size } = plainFiles['16-MB'];
           // TODO Update correctness trial to take crypto types
           await correctnessTrial(path, streamType, size, 'correctness');
         });

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@opentdf/client": "file:../lib/opentdf-client-0.4.0.tgz",
+        "native-file-system-adapter": "^3.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -18,6 +19,7 @@
         "@rollup/plugin-inject": "^5.0.3",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "@types/wicg-file-system-access": "^2020.9.5",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
         "@vitejs/plugin-react": "^3.0.1",
@@ -1442,9 +1444,9 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -2165,7 +2167,7 @@
     "node_modules/@opentdf/client": {
       "version": "0.4.0",
       "resolved": "file:../lib/opentdf-client-0.4.0.tgz",
-      "integrity": "sha512-46OzwYNeQP3hE2H/5m3i8W4Ltr2w4K6rrWLYbbD2Q/2//V5T3zC+PifUZXfaXnBBItmHBqOagNC5vz+smLn9PQ==",
+      "integrity": "sha512-7wlJTGgWHMlwiZGZvp9hjEQJmL0TdRiyc6gyWOOPTK3Wnv8ElnniBZA4qNQFdQ51P2Y7w+lCEqD56lB/XCCF/g==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/client-s3": "3.197.0",
@@ -2313,6 +2315,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3461,6 +3469,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -4121,6 +4152,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/native-file-system-adapter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-file-system-adapter/-/native-file-system-adapter-3.0.0.tgz",
+      "integrity": "sha512-IXwQiLiS7UlrlUetr9rHp+6uAAHT3291w2FGse5rdrQ7YXKtZHaqC4+tEXHMXVcevwsJNB3c7q9KO1Iu3IxgLw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=14.8.0"
+      },
+      "optionalDependencies": {
+        "fetch-blob": "^3.2.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -4131,6 +4183,25 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "optional": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.8",
@@ -5218,6 +5289,15 @@
         "is-stream": "^1.1.0",
         "readable-stream-node-to-web": "^1.0.1",
         "web-streams-ponyfill": "^1.4.1"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-streams-ponyfill": {
@@ -6638,9 +6718,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.208.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
       "requires": {
         "tslib": "^2.3.1"
       },
@@ -7199,7 +7279,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-0.4.0.tgz",
-      "integrity": "sha512-46OzwYNeQP3hE2H/5m3i8W4Ltr2w4K6rrWLYbbD2Q/2//V5T3zC+PifUZXfaXnBBItmHBqOagNC5vz+smLn9PQ==",
+      "integrity": "sha512-7wlJTGgWHMlwiZGZvp9hjEQJmL0TdRiyc6gyWOOPTK3Wnv8ElnniBZA4qNQFdQ51P2Y7w+lCEqD56lB/XCCF/g==",
       "requires": {
         "@aws-sdk/client-s3": "3.197.0",
         "axios": "^1.2.3",
@@ -7313,6 +7393,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -8063,6 +8149,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "optional": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -8495,6 +8591,14 @@
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
     },
+    "native-file-system-adapter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/native-file-system-adapter/-/native-file-system-adapter-3.0.0.tgz",
+      "integrity": "sha512-IXwQiLiS7UlrlUetr9rHp+6uAAHT3291w2FGse5rdrQ7YXKtZHaqC4+tEXHMXVcevwsJNB3c7q9KO1Iu3IxgLw==",
+      "requires": {
+        "fetch-blob": "^3.2.0"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "dev": true
@@ -8504,6 +8608,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "optional": true
     },
     "node-releases": {
       "version": "2.0.8",
@@ -9177,6 +9287,12 @@
         "readable-stream-node-to-web": "^1.0.1",
         "web-streams-ponyfill": "^1.4.1"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "optional": true
     },
     "web-streams-ponyfill": {
       "version": "1.4.2",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@opentdf/client": "file:../lib/opentdf-client-0.4.0.tgz",
+    "native-file-system-adapter": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -24,6 +25,7 @@
     "@rollup/plugin-inject": "^5.0.3",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",
     "@vitejs/plugin-react": "^3.0.1",

--- a/web-app/public/sw.js
+++ b/web-app/public/sw.js
@@ -1,0 +1,89 @@
+const WRITE = 0;
+const PULL = 0;
+const ERROR = 1;
+const ABORT = 1;
+const CLOSE = 2;
+const PING = 3;
+
+/** @implements {UnderlyingSource} */
+class MessagePortSource {
+  /** @type {ReadableStreamController<any>} controller */
+  controller;
+
+  /** @param {MessagePort} port */
+  constructor(port) {
+    this.port = port;
+    this.port.onmessage = (evt) => this.onMessage(evt.data);
+  }
+
+  /**
+   * @param {ReadableStreamController<any>} controller
+   */
+  start(controller) {
+    this.controller = controller;
+  }
+
+  /** @param {Error} reason */
+  cancel(reason) {
+    // Firefox can notify a cancel event, chrome can't
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=638494
+    this.port.postMessage({ type: ERROR, reason: reason.message });
+    this.port.close();
+  }
+
+  /** @param {{ type: number; chunk: Uint8Array; reason: any; }} message */
+  onMessage(message) {
+    // enqueue() will call pull() if needed when there's no backpressure
+    if (message.type === WRITE) {
+      this.controller.enqueue(message.chunk);
+      this.port.postMessage({ type: PULL });
+    }
+    if (message.type === ABORT) {
+      this.controller.error(message.reason);
+      this.port.close();
+    }
+    if (message.type === CLOSE) {
+      this.controller.close();
+      this.port.close();
+    }
+  }
+}
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+const map = new Map();
+
+// This should be called once per download
+// Each event has a dataChannel that the data will be piped through
+globalThis.addEventListener('message', (evt) => {
+  if (evt.origin !== 'http://localhost:65432/') {
+    console.log(`invalid origin ${evt.origin}`);
+    return;
+  }
+  const data = evt.data;
+  if (data.url && data.readablePort) {
+    data.rs = new ReadableStream(
+      new MessagePortSource(evt.data.readablePort),
+      new CountQueuingStrategy({ highWaterMark: 4 })
+    );
+    map.set(data.url, data);
+  }
+});
+
+globalThis.addEventListener('fetch', (evt) => {
+  const url = evt.request.url;
+  const data = map.get(url);
+  if (!data) return null;
+  map.delete(url);
+  evt.respondWith(
+    new Response(data.rs, {
+      headers: data.headers,
+    })
+  );
+});

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type ChangeEvent } from 'react';
+import { showSaveFilePicker } from 'native-file-system-adapter';
 import './App.css';
 import {
   Client as Tdf3Client,
@@ -23,6 +24,15 @@ function decryptedFileName(encryptedFileName: string): string {
   return `${m[1]}.decrypted.${m[2]}`;
 }
 
+function decryptedFileExtension(encryptedFileName: string): string {
+  const m = encryptedFileName.match(/^(.+)\.(\w+)\.(ntdf|tdf|tdf\.html)$/);
+  if (!m) {
+    console.warn(`Unable to extract raw file name from ${encryptedFileName}`);
+    return `${encryptedFileName}.decrypted`;
+  }
+  return m[2];
+}
+
 const oidcClient = new OidcClient(
   'http://localhost:65432/auth/realms/tdf',
   'browsertest',
@@ -40,8 +50,28 @@ function saver(blob: Blob, name: string) {
   a.dispatchEvent(new MouseEvent('click'));
 }
 
+async function getNewFileHandle(
+  extension: string,
+  suggestedName: string
+): Promise<FileSystemFileHandle> {
+  const options = {
+    types: [
+      {
+        description: `${extension} files`,
+        accept: {
+          'application/octet-stream': [`.${extension}`],
+        },
+      },
+    ],
+    suggestedName,
+  };
+  return showSaveFilePicker(options);
+}
+
 type Containers = 'html' | 'tdf' | 'nano';
+type CurrentDataController = AbortController | undefined;
 type InputSource = { file: File } | { url: URL } | undefined;
+type SinkType = 'file' | 'fsapi' | 'none';
 
 function fileNameFor(inputSource: InputSource) {
   if (!inputSource) {
@@ -55,11 +85,41 @@ function fileNameFor(inputSource: InputSource) {
   return pathname.slice(i + 1);
 }
 
+function drain() {
+  let byteCounter = 0;
+  let startTime: number;
+  let lastLogTime = 0;
+  return new WritableStream({
+    start() {
+      startTime = Date.now();
+    },
+    write(chunk) {
+      byteCounter += chunk.byteLength;
+      const now = Date.now();
+      if (now - lastLogTime > 1000) {
+        console.log(
+          `Dumped ${chunk.byteLength.toLocaleString()} of ${byteCounter.toLocaleString()}`
+        );
+        lastLogTime = now;
+      }
+    },
+    close() {
+      const elapsedSeconds = (Date.now() - startTime) / 1000;
+      console.log(
+        `Closed after ${byteCounter.toLocaleString()} bytes after ${elapsedSeconds.toLocaleString()} seconds`
+      );
+    },
+  });
+}
+
 function App() {
-  const [inputSource, setInputSource] = useState<InputSource>();
   const [authState, setAuthState] = useState<SessionInformation>({ sessionState: 'start' });
-  const [decryptContainerType, setDecryptContainerType] = useState<Containers>('nano');
-  const [encryptContainerType, setEncryptContainerType] = useState<Containers>('nano');
+  const [decryptContainerType, setDecryptContainerType] = useState<Containers>('tdf');
+  const [downloadState, setDownloadState] = useState<string | undefined>();
+  const [encryptContainerType, setEncryptContainerType] = useState<Containers>('tdf');
+  const [inputSource, setInputSource] = useState<InputSource>();
+  const [sinkType, setSinkType] = useState<SinkType>('file');
+  const [streamController, setStreamController] = useState<CurrentDataController>();
 
   const handleContainerFormatRadioChange =
     (handler: typeof setDecryptContainerType) => (e: ChangeEvent<HTMLInputElement>) => {
@@ -91,6 +151,51 @@ function App() {
     }
   };
 
+  const makeProgressPair = (fileSize: number, type: 'Encrypt' | 'Decrypt') => {
+    let bytesRead = 0;
+    let lastLoggedRead = -1;
+    let lastLoggedWritten = -1;
+    let bytesWritten = 0;
+    const logEveryBytes = fileSize && fileSize > 100 ? fileSize / 100 : 1000 * 1000 * 16;
+    return {
+      reader: new TransformStream({
+        async transform(chunk, controller) {
+          bytesRead += chunk.length;
+          const message = `🤓 Processed ${Math.round(
+            100 * (bytesRead / fileSize)
+          )}% input bytes (${bytesRead} / ${fileSize})`;
+          if (bytesRead - lastLoggedRead > logEveryBytes) {
+            console.log(message);
+            lastLoggedRead = bytesRead;
+          }
+          controller.enqueue(chunk);
+          setDownloadState(message);
+        },
+        flush() {
+          // NOTE AFAICT this is never called?
+          // What is the contract here? I'm guessing if the input and output queues
+          // are both empty this is not invoked? But how can the controller track state?
+          // For example, imagine a 'wait one tick' transform, which always outputs
+          // the previous transform input, but stores in an inner buffer?
+          setDownloadState(`🤓 ${type} Complete`);
+        },
+      }),
+      writer: new TransformStream({
+        async transform(chunk, controller) {
+          bytesWritten += chunk.length;
+          if (bytesWritten - lastLoggedWritten > logEveryBytes) {
+            console.log(`✍️ Processed output bytes: ${bytesWritten}`);
+            lastLoggedWritten = bytesWritten;
+          }
+          controller.enqueue(chunk);
+        },
+        flush() {
+          setDownloadState(`✍️ ${type} Complete`);
+        },
+      }),
+    };
+  };
+
   const handleEncrypt = async () => {
     if (!inputSource) {
       console.warn('PLEASE SELECT FILE ∨ URL');
@@ -101,14 +206,14 @@ function App() {
       console.warn('PLEASE LOG IN');
       return false;
     }
+    const inputFileName = fileNameFor(inputSource);
+    console.log(`Encrypting [${inputFileName}] as ${encryptContainerType} to ${sinkType}`);
     const authProvider = await AuthProviders.refreshAuthProvider({
       exchange: 'refresh',
       clientId: oidcClient.clientId,
       oidcOrigin: oidcClient.host,
       refreshToken,
     });
-    const inputFileName = fileNameFor(inputSource);
-    console.log(`Encrypting [${inputFileName}] to ${encryptContainerType} container'`);
     switch (encryptContainerType) {
       case 'nano': {
         if (!('file' in inputSource)) {
@@ -116,8 +221,32 @@ function App() {
         }
         const plainText = await inputSource.file.arrayBuffer();
         const nanoClient = new NanoTDFClient(authProvider, 'http://localhost:65432/api/kas');
-        const cipherText = await nanoClient.encrypt(plainText);
-        saver(new Blob([cipherText]), `${inputFileName}.ntdf`);
+        setDownloadState('Encrypting...');
+        switch (sinkType) {
+          case 'file':
+            {
+              const cipherText = await nanoClient.encrypt(plainText);
+              saver(new Blob([cipherText]), `${inputFileName}.ntdf`);
+            }
+            break;
+          case 'fsapi':
+            {
+              const file = await getNewFileHandle('ntdf', `${inputFileName}.ntdf`);
+              const cipherText = await nanoClient.encrypt(plainText);
+              const writable = await file.createWritable();
+              try {
+                await writable.write(cipherText);
+                setDownloadState('Encrypt Complete');
+              } catch (e) {
+                setDownloadState(`Encrypt Failed: ${e}`);
+              } finally {
+                await writable.close();
+              }
+            }
+            break;
+          case 'none':
+            break;
+        }
         break;
       }
       case 'html': {
@@ -126,11 +255,17 @@ function App() {
           kasEndpoint: 'http://localhost:65432/api/kas',
           readerUrl: 'https://secure.virtru.com/start?htmlProtocol=1',
         });
-        let source;
+        let source: ReadableStream<Uint8Array>, size: number;
+        const sc = new AbortController();
+        setStreamController(sc);
         if ('file' in inputSource) {
+          size = inputSource.file.size;
           source = inputSource.file.stream() as unknown as ReadableStream<Uint8Array>;
         } else {
-          const fr = await fetch(inputSource.url);
+          // NOTE: Attaching the signal to the pipeline (in pipeTo, below)
+          // is insufficient (at least in Chrome) to abort the fetch itself.
+          // So aborting a sink in a pipeline does *NOT* cancel its sources
+          const fr = await fetch(inputSource.url, { signal: sc.signal });
           if (!fr.ok) {
             throw Error(
               `Error on fetch [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
@@ -141,19 +276,42 @@ function App() {
               `Failed to fetch input [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
             );
           }
+          size = parseInt(fr.headers.get('Content-Length') || '-1');
           source = fr.body;
         }
         try {
+          const downloadName = `${inputFileName}.tdf.html`;
+          let f;
+          if (sinkType == 'fsapi') {
+            f = await getNewFileHandle('html', downloadName);
+          }
+          const progressTransformers = makeProgressPair(size, 'Encrypt');
           const cipherText = await client.encrypt({
-            source,
+            source: source.pipeThrough(progressTransformers.reader),
             offline: true,
             asHtml: true,
           });
-          const downloadName = `${inputFileName}.tdf.html`;
-          await cipherText.toFile(downloadName);
+          cipherText.stream = cipherText.stream.pipeThrough(progressTransformers.writer);
+          switch (sinkType) {
+            case 'file':
+              await cipherText.toFile(downloadName, { signal: sc.signal });
+              break;
+            case 'fsapi':
+              if (!f) {
+                throw new Error();
+              }
+              const writable = await f.createWritable();
+              await cipherText.stream.pipeTo(writable, { signal: sc.signal });
+              break;
+            case 'none':
+              await cipherText.stream.pipeTo(drain(), { signal: sc.signal });
+              break;
+          }
         } catch (e) {
+          setDownloadState(`Encrypt Failed: ${e}`);
           console.error('Encrypt Failed', e);
         }
+        setStreamController(undefined);
         break;
       }
       case 'tdf': {
@@ -161,11 +319,14 @@ function App() {
           authProvider,
           kasEndpoint: 'http://localhost:65432/api/kas',
         });
-        let source;
+        const sc = new AbortController();
+        setStreamController(sc);
+        let source: ReadableStream<Uint8Array>, size: number;
         if ('file' in inputSource) {
+          size = inputSource.file.size;
           source = inputSource.file.stream() as unknown as ReadableStream<Uint8Array>;
         } else {
-          const fr = await fetch(inputSource.url);
+          const fr = await fetch(inputSource.url, { signal: sc.signal });
           if (!fr.ok) {
             throw Error(
               `Error on fetch [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
@@ -176,17 +337,41 @@ function App() {
               `Failed to fetch input [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
             );
           }
+          size = parseInt(fr.headers.get('Content-Length') || '-1');
           source = fr.body;
         }
         try {
+          let f;
+          const downloadName = `${inputFileName}.tdf`;
+          if (sinkType === 'fsapi') {
+            f = await getNewFileHandle('tdf', downloadName);
+          }
+          const progressTransformers = makeProgressPair(size, 'Encrypt');
           const cipherText = await client.encrypt({
-            source,
+            source: source.pipeThrough(progressTransformers.reader),
             offline: true,
           });
-          await cipherText.toFile(`${inputFileName}.tdf`);
+          cipherText.stream = cipherText.stream.pipeThrough(progressTransformers.writer);
+          switch (sinkType) {
+            case 'file':
+              await cipherText.toFile(downloadName, { signal: sc.signal });
+              break;
+            case 'fsapi':
+              if (!f) {
+                throw new Error();
+              }
+              const writable = await f.createWritable();
+              await cipherText.stream.pipeTo(writable, { signal: sc.signal });
+              break;
+            case 'none':
+              await cipherText.stream.pipeTo(drain(), { signal: sc.signal });
+              break;
+          }
         } catch (e) {
+          setDownloadState(`Encrypt Failed: ${e}`);
           console.error('Encrypt Failed', e);
         }
+        setStreamController(undefined);
         break;
       }
     }
@@ -202,13 +387,20 @@ function App() {
       console.error('decrypt while logged out doesnt work');
       return false;
     }
+    const dfn = decryptedFileName(fileNameFor(inputSource));
+    console.log(
+      `Decrypting ${decryptContainerType} ${JSON.stringify(inputSource)} to ${sinkType} ${dfn}`
+    );
     const authProvider = await AuthProviders.refreshAuthProvider({
       exchange: 'refresh',
       clientId: oidcClient.clientId,
       oidcOrigin: oidcClient.host,
       refreshToken: authState.user.refreshToken,
     });
-    const dfn = decryptedFileName(fileNameFor(inputSource));
+    let f;
+    if (sinkType === 'fsapi') {
+      f = await getNewFileHandle(decryptedFileExtension(fileNameFor(inputSource)), dfn);
+    }
     switch (decryptContainerType) {
       case 'tdf': {
         const client = new Tdf3Client.Client({
@@ -216,17 +408,46 @@ function App() {
           kasEndpoint: 'http://localhost:65432/api/kas',
         });
         try {
+          const sc = new AbortController();
+          setStreamController(sc);
           let source: DecryptSource;
+          let size: number;
           if ('file' in inputSource) {
+            size = inputSource.file.size;
             source = { type: 'file-browser', location: inputSource.file };
           } else {
+            const hr = await fetch(inputSource.url, { method: 'HEAD' });
+            size = parseInt(hr.headers.get('Content-Length') || '-1');
             source = { type: 'remote', location: inputSource.url.toString() };
           }
+          const progressTransformers = makeProgressPair(size, 'Decrypt');
+          // XXX chunker doesn't have an equivalent 'stream' interaface
+          // so we kinda fake it with percentages by tracking output, which should
+          // strictly be smaller than the input file.
           const plainText = await client.decrypt({ source });
-          await plainText.toFile(dfn);
+          plainText.stream = plainText.stream
+            .pipeThrough(progressTransformers.reader)
+            .pipeThrough(progressTransformers.writer);
+          switch (sinkType) {
+            case 'file':
+              await plainText.toFile(dfn, { signal: sc.signal });
+              break;
+            case 'fsapi':
+              if (!f) {
+                throw new Error();
+              }
+              const writable = await f.createWritable();
+              await plainText.stream.pipeTo(writable, { signal: sc.signal });
+              break;
+            case 'none':
+              await plainText.stream.pipeTo(drain(), { signal: sc.signal });
+              break;
+          }
         } catch (e) {
           console.error('Decrypt Failed', e);
+          setDownloadState(`Decrypt Failed: ${e}`);
         }
+        setStreamController(undefined);
         break;
       }
       case 'nano': {
@@ -234,12 +455,110 @@ function App() {
           throw new Error('Unsupported : fetch the url I guess?');
         }
         const nanoClient = new NanoTDFClient(authProvider, 'http://localhost:65432/api/kas');
-        const plainText = await nanoClient.decrypt(await inputSource.file.arrayBuffer());
-        saver(new Blob([plainText]), dfn);
+        try {
+          const plainText = await nanoClient.decrypt(await inputSource.file.arrayBuffer());
+          switch (sinkType) {
+            case 'file':
+              saver(new Blob([plainText]), dfn);
+              break;
+            case 'fsapi':
+              if (!f) {
+                throw new Error();
+              }
+              const writable = await f.createWritable();
+              try {
+                await writable.write(plainText);
+                setDownloadState('Decrypt Complete');
+              } finally {
+                await writable.close();
+              }
+              break;
+            case 'none':
+              break;
+          }
+        } catch (e) {
+          console.error('Decrypt Failed', e);
+          setDownloadState(`Decrypt Failed: ${e}`);
+        }
         break;
       }
     }
     return false;
+  };
+
+  const handleScan = async () => {
+    const searchTerm = 'service workers';
+    // Chars to show either side of the result in the match
+    const contextBefore = 30;
+    const contextAfter = 30;
+    const caseInsensitive = true;
+
+    if (!inputSource) {
+      console.warn('PLEASE SELECT FILE ∨ URL');
+      return false;
+    }
+    let source;
+    if ('file' in inputSource) {
+      source = inputSource.file.stream() as unknown as ReadableStream<Uint8Array>;
+    } else {
+      const sc = new AbortController();
+      setStreamController(sc);
+      const fr = await fetch(inputSource.url, { cache: 'no-store', signal: sc.signal });
+      console.log(`Received headers ${fr.headers}`);
+      if (!fr.ok) {
+        throw Error(
+          `Error on fetch [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
+        );
+      }
+      if (!fr.body) {
+        throw Error(
+          `Failed to fetch input [${inputSource.url}]: ${fr.status} code received; [${fr.statusText}]`
+        );
+      }
+      source = fr.body;
+    }
+    const reader = source.getReader();
+
+    const decoder = new TextDecoder();
+    const toMatch = caseInsensitive ? searchTerm.toLowerCase() : searchTerm;
+    const bufferSize = Math.max(toMatch.length - 1, contextBefore);
+
+    let bytesReceived = 0;
+    let buffer = '';
+    let matchFoundAt = -1;
+
+    while (true) {
+      const { value: chunk, done } = await reader.read();
+      if (done) {
+        console.log('Failed to find match');
+        return;
+      }
+      bytesReceived += chunk.length;
+      console.log(`Received ${bytesReceived.toLocaleString()} bytes of data so far`);
+      buffer += decoder.decode(chunk, { stream: true });
+
+      // already found match & just context-gathering?
+      if (matchFoundAt === -1) {
+        matchFoundAt = (caseInsensitive ? buffer.toLowerCase() : buffer).indexOf(toMatch);
+      }
+
+      if (matchFoundAt === -1) {
+        buffer = buffer.slice(-bufferSize);
+      } else if (buffer.slice(matchFoundAt + toMatch.length).length >= contextAfter) {
+        console.log("Here's the match:");
+        console.log(
+          buffer.slice(
+            Math.max(0, matchFoundAt - contextBefore),
+            matchFoundAt + toMatch.length + contextAfter
+          )
+        );
+        console.log('Cancelling fetch');
+        reader.cancel();
+        return;
+      } else {
+        console.log('Found match, but need more context…');
+      }
+    }
   };
 
   const SessionInfo =
@@ -271,39 +590,103 @@ function App() {
         {SessionInfo}
       </div>
       <div className="body">
-        <div className="input">
-          {hasFileInput ? (
-            <div id="details">
-              <h2>{'file' in inputSource ? inputSource.file.name : inputSource.url.toString()}</h2>
-              {'file' in inputSource && (
-                <>
-                  <div id="contentType">Content Type: {inputSource.file.type}</div>
-                  <div>
-                    Last Modified: {new Date(inputSource.file.lastModified).toLocaleString()}
-                  </div>
-                  <div>Size: {new Intl.NumberFormat().format(inputSource.file.size)} bytes</div>
-                </>
-              )}
-              <button id="clearFile" onClick={() => setInputSource(undefined)} type="button">
-                Clear file
-              </button>
-            </div>
-          ) : (
-            <>
-              <label htmlFor="file-selector">Select file:</label>
-              <input type="file" name="file" id="fileSelector" onChange={changeHandler} />
-              <div>OR URL:</div>
+        <div className="config horizontal-flow">
+          <fieldset className="input">
+            <legend>Source</legend>
+            {hasFileInput ? (
+              <div id="details">
+                <h2>
+                  {'file' in inputSource ? inputSource.file.name : inputSource.url.toString()}
+                </h2>
+                {'file' in inputSource && (
+                  <>
+                    <div id="contentType">Content Type: {inputSource.file.type}</div>
+                    <div>
+                      Last Modified: {new Date(inputSource.file.lastModified).toLocaleString()}
+                    </div>
+                    <div>Size: {new Intl.NumberFormat().format(inputSource.file.size)} bytes</div>
+                  </>
+                )}
+                <button
+                  id="clearFile"
+                  onClick={() => {
+                    setInputSource(undefined);
+                    setDownloadState(undefined);
+                  }}
+                  type="button"
+                >
+                  Clear file
+                </button>
+              </div>
+            ) : (
+              <>
+                <label htmlFor="file-selector">Select file:</label>
+                <input type="file" name="file" id="fileSelector" onChange={changeHandler} />
+                <div>OR URL:</div>
+                <input
+                  type="url"
+                  name="url"
+                  id="urlSelector"
+                  onChange={changeHandler}
+                  placeholder="http://localhost:8000/sample.tdf"
+                />
+              </>
+            )}
+          </fieldset>
+
+          <fieldset className="Output">
+            <legend>Sink</legend>
+            <div>
               <input
-                type="url"
-                name="url"
-                id="urlSelector"
-                onChange={changeHandler}
-                placeholder="http://localhost:8000/sample.tdf"
-              />
-            </>
-          )}
+                type="radio"
+                id="fileSink"
+                name="sinkType"
+                value="file"
+                onChange={(e) => setSinkType(e.target.value as SinkType)}
+                checked={sinkType === 'file'}
+              />{' '}
+              <label htmlFor="fileSink">Download</label>
+              <br />
+              <input
+                type="radio"
+                id="fsapiSink"
+                name="sinkType"
+                value="fsapi"
+                onChange={(e) => setSinkType(e.target.value as SinkType)}
+                checked={sinkType === 'fsapi'}
+              />{' '}
+              <label htmlFor="fsapiSink">Save As</label>
+              <br />
+              <input
+                type="radio"
+                id="noneSink"
+                name="sinkType"
+                value="none"
+                onChange={(e) => setSinkType(e.target.value as SinkType)}
+                checked={sinkType === 'none'}
+              />{' '}
+              <label htmlFor="noneSink">Dump</label>
+            </div>
+          </fieldset>
         </div>
-        {inputSource && (
+
+        {streamController && (
+          <div className="action">
+            <button
+              id="cancelStream"
+              onClick={async () => {
+                console.log(`Cancelling !!!!`);
+                const p = streamController.abort();
+                setStreamController(undefined);
+                await p;
+              }}
+              type="button"
+            >
+              CANCEL
+            </button>
+          </div>
+        )}
+        {inputSource && !streamController && (
           <div className="action">
             <form className="column">
               <h2>Encrypt</h2>
@@ -317,7 +700,7 @@ function App() {
                     onChange={handleContainerFormatRadioChange(setEncryptContainerType)}
                     checked={encryptContainerType === 'html'}
                   />{' '}
-                  <label htmlFor="html">HTML</label>
+                  <label htmlFor="htmlEncrypt">HTML</label>
                   <br />
                   <input
                     type="radio"
@@ -327,7 +710,7 @@ function App() {
                     onChange={handleContainerFormatRadioChange(setEncryptContainerType)}
                     checked={encryptContainerType === 'tdf'}
                   />{' '}
-                  <label htmlFor="zip">TDF</label>
+                  <label htmlFor="zipEncrypt">TDF</label>
                   <br />
                   <input
                     type="radio"
@@ -337,10 +720,13 @@ function App() {
                     onChange={handleContainerFormatRadioChange(setEncryptContainerType)}
                     checked={encryptContainerType === 'nano'}
                   />{' '}
-                  <label htmlFor="nano">nano</label>
+                  <label htmlFor="nanoEncrypt">nano</label>
                 </div>
                 <button id="encryptButton" onClick={() => handleEncrypt()} type="button">
                   Encrypt
+                </button>
+                <button id="scanButton" onClick={() => handleScan()} type="button">
+                  DEMO
                 </button>
               </div>
             </form>
@@ -356,7 +742,7 @@ function App() {
                     onChange={handleContainerFormatRadioChange(setDecryptContainerType)}
                     checked={decryptContainerType === 'tdf'}
                   />{' '}
-                  <label htmlFor="tdf">TDF</label>
+                  <label htmlFor="tdfDecrypt">TDF</label>
                   <br />
                   <input
                     type="radio"
@@ -366,13 +752,14 @@ function App() {
                     onChange={handleContainerFormatRadioChange(setDecryptContainerType)}
                     checked={decryptContainerType === 'nano'}
                   />{' '}
-                  <label htmlFor="nano">nano</label>
+                  <label htmlFor="nanoDecrypt">nano</label>
                 </div>
                 <button id="decryptButton" onClick={() => handleDecrypt()} type="button">
                   decrypt
                 </button>
               </div>
             </form>
+            {downloadState && <div id="downloadState">{downloadState}</div>}
           </div>
         )}
       </div>

--- a/web-app/src/main.tsx
+++ b/web-app/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App.js';
 import './index.css';
 
+navigator.serviceWorker.register('./sw.js');
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/web-app/tests/README.md
+++ b/web-app/tests/README.md
@@ -43,7 +43,7 @@ To try encrypting some of your own files via HTTP:
 ```
 cd web-app/tests
 npm i
-./run-server.js ~/my-test-documents
+./run-server.js ~/Downloads
 ```
 
 Then use the OR URL field in the sample app to load things up.

--- a/web-app/tests/package-lock.json
+++ b/web-app/tests/package-lock.json
@@ -9,24 +9,27 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.30.0",
+        "@playwright/test": "^1.31.2",
         "send": "^0.18.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
-      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
+      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.30.0"
+        "playwright-core": "1.31.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@types/node": {
@@ -108,6 +111,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -161,9 +178,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
+      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -232,13 +249,14 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
-      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
+      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.30.0"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.31.2"
       }
     },
     "@types/node": {
@@ -306,6 +324,13 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -347,9 +372,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
+      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
       "dev": true
     },
     "range-parser": {

--- a/web-app/tests/package.json
+++ b/web-app/tests/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.30.0",
+    "@playwright/test": "^1.31.2",
     "send": "^0.18.0"
   }
 }

--- a/web-app/tests/playwright.config.ts
+++ b/web-app/tests/playwright.config.ts
@@ -15,14 +15,8 @@ const config: PlaywrightTestConfig = {
   /* Maximum time one test can run for. */
   timeout: 10 * 1000,
   expect: {
-    /**
-     * Maximum time expect() should wait for the condition to be met.
-     * For example in `await expect(locator).toHaveText();`
-     */
     timeout: 3000,
   },
-  /* Run tests in files in parallel */
-  fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */

--- a/web-app/tests/static-server.js
+++ b/web-app/tests/static-server.js
@@ -20,6 +20,7 @@ export async function serve(path, port) {
     if (req.headers?.origin) {
       res.setHeader('Access-Control-Allow-Headers', req.headers.origin);
     }
+    res.setHeader('Access-Control-Expose-Headers', 'Content-Length');
     const url = new URL(req.url, `http://${req.headers.host}`);
     const validNamePart = NodePath.basename(url.pathname);
     const allowedName = `/${validNamePart}`;

--- a/web-app/tsconfig.json
+++ b/web-app/tsconfig.json
@@ -21,6 +21,6 @@
     "target": "ESNext",
     "useDefineForClassFields": true
   },
-  "include": ["src"],
+  "include": ["src", "public/sw.js"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Adds a few alternatives and buttons to see if where the different bugs might exist. notably:

1. Adds a 'how to save' selector, to allow dumping the stream, for selecting between Streamsaver (default download), fsapi (called Save As... although only Chrome actually opens the file save dialog), and 'none' (dump to a null writer). 
2. Adds a 'demo scan' button, which doesn't use our library at all but just does some text processing from a Jake Archibald demo
3. Adds a rate limited progress logger to the console
4. Adds 'cancel' button to abort longer streams