### PR TITLE
🐛 Lets unwrapHtml take a string

### DIFF
--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -184,8 +184,13 @@ export class TDF extends EventEmitter {
     return Buffer.from(fullHtmlString);
   }
 
-  static unwrapHtml(htmlPayload: Uint8Array) {
-    const html = new TextDecoder().decode(htmlPayload);
+  static unwrapHtml(htmlPayload: ArrayBuffer | Uint8Array | Binary | string) {
+    let html;
+    if (htmlPayload instanceof ArrayBuffer || ArrayBuffer.isView(htmlPayload)) {
+      html = new TextDecoder().decode(htmlPayload);
+    } else {
+      html = htmlPayload.toString();
+    }
     const payloadRe = /<input id=['"]?data-input['"]?[^>]*value=['"]?([a-zA-Z0-9+/=]+)['"]?/;
     const reResult = payloadRe.exec(html);
     if (reResult === null) {

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -29,7 +29,8 @@ describe('TDF', () => {
     const cipherText = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2]);
     const transferUrl = 'https://local.virtru.com/start?htmlProtocol=1';
     const wrapped = TDF.wrapHtml(cipherText, JSON.stringify({ thisIs: 'metadata' }), transferUrl);
-    const unwrapped = TDF.unwrapHtml(wrapped);
-    expect(unwrapped).to.eql(cipherText);
+    expect(TDF.unwrapHtml(wrapped)).to.eql(cipherText);
+    expect(TDF.unwrapHtml(wrapped.buffer)).to.eql(cipherText);
+    expect(TDF.unwrapHtml(wrapped.toString('utf-8'))).to.eql(cipherText);
   });
 });


### PR DESCRIPTION
We use this behavior in protect-and-track, as part of 'download tdf' hack