### PR TITLE
🚨 Require allowlisting KASes on decrypt and upsert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-version=1.2.2
+version=1.3.0
 pkgs=lib web-app
 
 .PHONY: all audit license-check lint test ci i start format clean

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opentdf/client",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@opentdf/client",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/abort-controller": "^3.370.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentdf/client",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Access and generate tdf protected content",
   "homepage": "https://github.com/opentdf/client-web",
   "bugs": {

--- a/lib/src/nanotdf/Client.ts
+++ b/lib/src/nanotdf/Client.ts
@@ -13,6 +13,7 @@ import getHkdfSalt from './helpers/getHkdfSalt.js';
 import DefaultParams from './models/DefaultParams.js';
 import { fetchWrappedKey } from '../kas.js';
 import { AuthProvider, reqSignature } from '../auth/providers.js';
+import { safeUrlCheck, validateSecureUrl } from '../utils.js';
 
 const { KeyUsageType, AlgorithmName, NamedCurve } = cryptoEnums;
 
@@ -52,6 +53,7 @@ export default class Client {
   static readonly INITIAL_RELEASE_IV_SIZE = 3;
   static readonly IV_SIZE = 12;
 
+  allowedKases: string[];
   /*
     These variables are expected to be either assigned during initialization or within the methods.
     This is needed as the flow is very specific. Errors should be thrown if the necessary step is not completed.
@@ -80,7 +82,9 @@ export default class Client {
     dpopEnabled = false
   ) {
     this.authProvider = authProvider;
+    validateSecureUrl(kasUrl);
     this.kasUrl = kasUrl;
+    this.allowedKases = [kasUrl];
     this.kasPubKey = '';
     this.dpopEnabled = dpopEnabled;
 
@@ -186,6 +190,8 @@ export default class Client {
     clientVersion: string,
     authTagLength: number
   ): Promise<CryptoKey> {
+    safeUrlCheck(this.allowedKases, kasRewrapUrl);
+
     // Ensure the ephemeral key pair has been set or generated (see createOidcServiceProvider)
     await this.fetchOIDCToken();
 

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -1,5 +1,59 @@
 import { type AxiosResponseHeaders, type RawAxiosResponseHeaders } from 'axios';
 
+/**
+ * Check to see if the given URL is 'secure'. This assumes:
+ *
+ * - `https` URLs are always secure
+ * - `http` URLS are allowed for localhost
+ * - And also for '`svc.cluster.local` and `.internal` URLs
+ *
+ * Note that this does not resolve the URL, so it is possible this could
+ * resolve to some other internal URL, and may return `false` on non-fully
+ * qualified internal URLs.
+ *
+ * @param url remote service to validate
+ * @returns the url is local or `https`
+ */
+export function validateSecureUrl(url: string): boolean {
+  const httpsRegex = /^https:/;
+  if (/^http:\/\/(localhost|127\.0\.0\.1)(:[0-9]{1,5})?($|\/)/.test(url)) {
+    console.warn(`Development URL detected: [${url}]`);
+  } else if (
+    /^http:\/\/([a-zA-Z.-]*[.])?svc\.cluster\.local($|\/)/.test(url) ||
+    /^http:\/\/([a-zA-Z.-]*[.])?internal(:[0-9]{1,5})?($|\/)/.test(url)
+  ) {
+    console.info(`Internal URL detected: [${url}]`);
+  } else if (!httpsRegex.test(url)) {
+    console.error(`Insecure KAS URL loaded. Are you running in a secure environment? [${url}]`);
+    return false;
+  }
+  return true;
+}
+
+export function padSlashToUrl(u: string): string {
+  if (u.endsWith('/')) {
+    return u;
+  }
+  return `${u}/`;
+}
+
+const someStartsWith = (prefixes: string[], requestUrl: string): boolean =>
+  prefixes.some((prixfixe) => requestUrl.startsWith(padSlashToUrl(prixfixe)));
+
+/**
+ * Checks that `testUrl` is prefixed with one of the given origin + path fragment URIs in urlPrefixes.
+ *
+ * Note this doesn't do anything special to queries or fragments and will fail to work properly if those are present on the prefixes
+ * @param urlPrefixes a list of origin parts of urls, possibly including some path fragment as well
+ * @param testUrl a url to see if it is prefixed by one or more of the `urlPrefixes` values
+ * @throws Error when testUrl is not present
+ */
+export const safeUrlCheck = (urlPrefixes: string[], testUrl: string): void | never => {
+  if (!someStartsWith(urlPrefixes, testUrl)) {
+    throw new Error(`Invalid request URL: [${testUrl}] ∉ [${urlPrefixes}];`);
+  }
+};
+
 export function isBrowser() {
   return typeof window !== 'undefined'; // eslint-disable-line
 }

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -1,4 +1,5 @@
 import { type AxiosResponseHeaders, type RawAxiosResponseHeaders } from 'axios';
+import { UnsafeUrlError } from '../tdf3/src/errors.js';
 
 /**
  * Check to see if the given URL is 'secure'. This assumes:
@@ -50,7 +51,7 @@ const someStartsWith = (prefixes: string[], requestUrl: string): boolean =>
  */
 export const safeUrlCheck = (urlPrefixes: string[], testUrl: string): void | never => {
   if (!someStartsWith(urlPrefixes, testUrl)) {
-    throw new Error(`Invalid request URL: [${testUrl}] ∉ [${urlPrefixes}];`);
+    throw new UnsafeUrlError(`Invalid request URL: [${testUrl}] ∉ [${urlPrefixes}];`, testUrl);
   }
 };
 

--- a/lib/src/version.ts
+++ b/lib/src/version.ts
@@ -1,7 +1,7 @@
 /**
  * Exposes the released version number of the `@opentdf/client` package
  */
-export const version = '1.2.2';
+export const version = '1.3.0';
 
 /**
  * A string name used to label requests as coming from this library client.

--- a/lib/tdf3/src/errors.ts
+++ b/lib/tdf3/src/errors.ts
@@ -27,6 +27,17 @@ export class TdfError extends Error {
   }
 }
 
+export class UnsafeUrlError extends Error {
+  override name = 'UnsafeUrlError';
+  readonly url: string;
+
+  constructor(message: string, url: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.url = url;
+  }
+}
+
 export class AttributeValidationError extends TdfError {
   override name = 'AttributeValidationError';
 }

--- a/lib/tdf3/src/version.ts
+++ b/lib/tdf3/src/version.ts
@@ -1,2 +1,2 @@
-export const version = '1.2.2';
+export const version = '1.3.0';
 export const clientType = 'tdf3-js-client';

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -50,6 +50,11 @@ describe('TDF', () => {
     expect(actual).to.be.an.instanceof(TDF);
   });
 
+  it('allowedKases', () => {
+    const actual = TDF.create({ allowedKases: ['https://local.virtru.com'], cryptoService });
+    expect(actual.allowedKases).to.contain('https://local.virtru.com');
+  });
+
   it('Encodes the postMessage origin properly in wrapHtml', () => {
     const cipherText = 'abcezas123';
     const transferUrl = 'https://local.virtru.com/start?htmlProtocol=1';

--- a/lib/tests/web/utils.test.ts
+++ b/lib/tests/web/utils.test.ts
@@ -1,7 +1,14 @@
 import { expect } from '@esm-bundle/chai';
 import axios from 'axios';
 import sinon from 'sinon';
-import { estimateSkew, estimateSkewFromHeaders, rstrip } from '../../src/utils.js';
+import {
+  estimateSkew,
+  estimateSkewFromHeaders,
+  padSlashToUrl,
+  rstrip,
+  safeUrlCheck,
+  validateSecureUrl,
+} from '../../src/utils.js';
 
 describe('rstrip', () => {
   describe('default', () => {
@@ -43,6 +50,80 @@ describe('rstrip', () => {
       expect(rstrip('https://hey.you/', '/')).to.eql('https://hey.you');
       expect(rstrip('https://hey.you//', '/')).to.eql('https://hey.you');
     });
+  });
+});
+
+describe('validateSecureUrl', () => {
+  it('https is preferred', () => {
+    expect(validateSecureUrl('https://my.xyz/somewhere')).to.be.true;
+    expect(validateSecureUrl('https://my.home')).to.be.true;
+    expect(validateSecureUrl('https://my.home:65432/')).to.be.true;
+    expect(validateSecureUrl('https://my.home:65432')).to.be.true;
+    expect(validateSecureUrl('http://my.home')).to.be.false;
+    expect(validateSecureUrl('http://my.home/')).to.be.false;
+    expect(validateSecureUrl('http://my.home:65432/')).to.be.false;
+    expect(validateSecureUrl('http://my.home:65432')).to.be.false;
+  });
+  it('allows locals', () => {
+    expect(validateSecureUrl('http://localhost/somewhere')).to.be.true;
+    expect(validateSecureUrl('http://127.0.0.1')).to.be.true;
+    expect(validateSecureUrl('http://127.0.0.1.com')).to.be.false;
+    expect(validateSecureUrl('http://127.0-0.1')).to.be.false;
+    expect(validateSecureUrl('http://localhost:12312/somewhere')).to.be.true;
+    expect(validateSecureUrl('http://localhost.com/somewhere')).to.be.false;
+  });
+  it('allows internals', () => {
+    expect(validateSecureUrl('http://docker.internal/somewhere')).to.be.true;
+    expect(validateSecureUrl('http://svc.cluster.local')).to.be.true;
+    expect(validateSecureUrl('http://amz.svc.cluster.local')).to.be.true;
+    expect(validateSecureUrl('http://somesvc.cluster.local')).to.be.false;
+  });
+  it('mangled urls', () => {
+    expect(validateSecureUrl('///hey.you')).to.be.false;
+    expect(validateSecureUrl('')).to.be.false;
+    expect(validateSecureUrl('https')).to.be.false;
+  });
+});
+
+describe('padSlashToUrl', () => {
+  it('slashadds', () => {
+    expect(padSlashToUrl('https://my.xyz')).to.equal('https://my.xyz/');
+    expect(padSlashToUrl('https://my.xyz/')).to.equal('https://my.xyz/');
+    expect(padSlashToUrl('https://my.xyz/somewhere')).to.equal('https://my.xyz/somewhere/');
+    expect(padSlashToUrl('https://my.xyz/somewhere/')).to.equal('https://my.xyz/somewhere/');
+  });
+});
+
+describe('safeUrlCheck', () => {
+  it('some checks', () => {
+    expect(() => safeUrlCheck([], 'https://my.xyz/somewhere/else')).to.throw('Invalid request URL');
+    expect(() => safeUrlCheck([''], 'https://my.xyz/somewhere/else')).to.throw(
+      'Invalid request URL'
+    );
+    expect(() => safeUrlCheck(['https://my.xyz'], 'https://my.xyz/somewhere')).to.not.throw(
+      'Invalid request URL'
+    );
+    expect(() => safeUrlCheck(['https://my.xyz'], 'https://my.xyz.com/somewhere/else')).to.throw(
+      'Invalid request URL'
+    );
+    expect(() => safeUrlCheck(['https://my.xyz'], 'http://my.xyz/somewhere/else')).to.throw(
+      'Invalid request URL'
+    );
+    expect(() =>
+      safeUrlCheck(['https://my.xyz/somewhere'], 'https://my.xyz/somewhere/else')
+    ).to.not.throw('Invalid request URL');
+    expect(() =>
+      safeUrlCheck(
+        ['https://your.place', 'https://my.xyz/somewhere'],
+        'https://my.xyz/somewhere/else'
+      )
+    ).to.not.throw('Invalid request URL');
+    expect(() =>
+      safeUrlCheck(['https://my.xyz/somewhere'], 'https://my.xyz/somewhereelse/')
+    ).to.throw('Invalid request URL');
+    expect(() => safeUrlCheck(['https://my.xyz/somewhere'], 'https://my.xyz/elsewhere/')).to.throw(
+      'Invalid request URL'
+    );
   });
 });
 

--- a/lib/tests/web/utils.test.ts
+++ b/lib/tests/web/utils.test.ts
@@ -125,6 +125,15 @@ describe('safeUrlCheck', () => {
       'Invalid request URL'
     );
   });
+
+  it('returns invalid url', () => {
+    try {
+      safeUrlCheck([], 'https://my.xyz/somewhere/else');
+      expect.fail();
+    } catch (e) {
+      expect(e).to.have.property('url', 'https://my.xyz/somewhere/else');
+    }
+  });
 });
 
 function mockApiResponse(date = '', status = 200) {

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "web-app",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-app",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "@opentdf/client": "file:../lib/opentdf-client-1.2.2.tgz",
+        "@opentdf/client": "file:../lib/opentdf-client-1.3.0.tgz",
         "clsx": "^2.0.0",
         "native-file-system-adapter": "^3.0.0",
         "react": "^18.2.0",
@@ -1685,9 +1685,9 @@
       }
     },
     "node_modules/@opentdf/client": {
-      "version": "1.2.2",
-      "resolved": "file:../lib/opentdf-client-1.2.2.tgz",
-      "integrity": "sha512-2Z/jYDq3+GLrv21U/pG8968Webgn0IbZmYolTJ+bvcVTaVsRco59OEe0A+Vvj0Relp8QNsp+Yh6qsa1orWb/cw==",
+      "version": "1.3.0",
+      "resolved": "file:../lib/opentdf-client-1.3.0.tgz",
+      "integrity": "sha512-oPANKmhAeUINdW8A6b+xPhIPjAHK0AHHyV/SbMiFIxybMiE7Ivn8S6BPRdnstNb2HCGIVh0Ed3PXt3jKnyqqoQ==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/abort-controller": "^3.370.0",
@@ -6982,8 +6982,8 @@
       }
     },
     "@opentdf/client": {
-      "version": "file:../lib/opentdf-client-1.2.2.tgz",
-      "integrity": "sha512-2Z/jYDq3+GLrv21U/pG8968Webgn0IbZmYolTJ+bvcVTaVsRco59OEe0A+Vvj0Relp8QNsp+Yh6qsa1orWb/cw==",
+      "version": "file:../lib/opentdf-client-1.3.0.tgz",
+      "integrity": "sha512-oPANKmhAeUINdW8A6b+xPhIPjAHK0AHHyV/SbMiFIxybMiE7Ivn8S6BPRdnstNb2HCGIVh0Ed3PXt3jKnyqqoQ==",
       "requires": {
         "@aws-sdk/abort-controller": "^3.370.0",
         "@aws-sdk/client-s3": "^3.379.1",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -197,62 +197,62 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.383.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.383.0.tgz",
-      "integrity": "sha512-8x3WtuGHy3mESB3UxbZKdrZgMDBqqyPdUGwnkM8YeC8VkGce5pS98OgYe350aUNSzTkE3dNipzYZtm2BjalAyA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.388.0.tgz",
+      "integrity": "sha512-9UN8gtr/4e4YnHb3Kb4VsxGTDe6olkL90ivK09jKwG2SX8m5OY2fIHSjtyqUHDuFb67JOk3WVEMbZEfxfx46+w==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.382.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.378.0",
-        "@aws-sdk/middleware-expect-continue": "3.378.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.383.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-location-constraint": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-sdk-s3": "3.379.1",
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-ssec": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/signature-v4-multi-region": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@aws-sdk/client-sts": "3.388.0",
+        "@aws-sdk/credential-provider-node": "3.388.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.387.0",
+        "@aws-sdk/middleware-expect-continue": "3.387.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.387.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-location-constraint": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-sdk-s3": "3.387.0",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/middleware-ssec": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/signature-v4-multi-region": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/eventstream-serde-browser": "^2.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^2.0.1",
-        "@smithy/eventstream-serde-node": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-blob-browser": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/hash-stream-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/md5-js": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/eventstream-serde-browser": "^2.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.2",
+        "@smithy/eventstream-serde-node": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-blob-browser": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/hash-stream-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/md5-js": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/util-stream": "^2.0.2",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.1",
+        "@smithy/util-waiter": "^2.0.2",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
@@ -261,83 +261,40 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.382.0.tgz",
-      "integrity": "sha512-ge11t4hJllOF8pBNF0p1X52lLqUsLGAoey24fvk3fyvvczeLpegGYh2kdLG0iwFTDgRxaUqK+kboH5Wy9ux/pw==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.387.0.tgz",
+      "integrity": "sha512-E7uKSvbA0XMKSN5KLInf52hmMpe9/OKo6N9OPffGXdn3fNEQlvyQq3meUkqG7Is0ldgsQMz5EUBNtNybXzr3tQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.382.0.tgz",
-      "integrity": "sha512-hTfvB1ftbrqaz7qiEkmRobzUQwG34oZlByobn8Frdr5ZQbJk969bX6evQAPyKlJEr26+kL9TnaX+rbLR/+gwHQ==",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -347,43 +304,43 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.388.0.tgz",
+      "integrity": "sha512-y9FAcAYHT8O6T/jqhgsIQUb4gLiSTKD3xtzudDvjmFi8gl0oRIY1npbeckSiK6k07VQugm2s64I0nDnDxtWsBg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-sdk-sts": "3.379.1",
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@aws-sdk/credential-provider-node": "3.388.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-sdk-sts": "3.387.0",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
@@ -394,13 +351,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
-      "integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.387.0.tgz",
+      "integrity": "sha512-PVqNk7XPIYe5CMYNvELkcALtkl/pIM8/uPtqEtTg+mgnZBeL4fAmgXZiZMahQo1DxP5t/JaK384f6JG+A0qDjA==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -408,19 +365,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.388.0.tgz",
+      "integrity": "sha512-3dg3A8AiZ5vXkSAYyyI3V/AW3Eo6KQJyE/glA+Nr2M0oAjT4z3vHhS3pf2B+hfKGZBTuKKgxusrrhrQABd/Diw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
-        "@aws-sdk/credential-provider-web-identity": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/credential-provider-env": "3.387.0",
+        "@aws-sdk/credential-provider-process": "3.387.0",
+        "@aws-sdk/credential-provider-sso": "3.388.0",
+        "@aws-sdk/credential-provider-web-identity": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -428,20 +385,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.388.0.tgz",
+      "integrity": "sha512-BqWAkIG08gj/wevpesaZhAjALjfUNVjseHQRk+DNUoHIfyibW7Ahf3q/GIPs11dA2o8ECwR9/fo68Sq+sK799A==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.382.0",
-        "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
-        "@aws-sdk/credential-provider-web-identity": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/credential-provider-env": "3.387.0",
+        "@aws-sdk/credential-provider-ini": "3.388.0",
+        "@aws-sdk/credential-provider-process": "3.387.0",
+        "@aws-sdk/credential-provider-sso": "3.388.0",
+        "@aws-sdk/credential-provider-web-identity": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -449,14 +406,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
-      "integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.387.0.tgz",
+      "integrity": "sha512-tQScLHmDlqkQN+mqw4s3cxepEUeHYDhFl5eH+J8puvPqWjXMYpCEdY79SAtWs6SZd4CWiZ0VLeYU6xQBZengbQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -464,16 +421,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.388.0.tgz",
+      "integrity": "sha512-RH02+rntaO0UhnSBr42n+7q8HOztc+Dets/hh6cWovf3Yi9s9ghLgYLN9FXpSosfot3XkmT/HOCa+CphAmGN9A==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.382.0",
-        "@aws-sdk/token-providers": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/client-sso": "3.387.0",
+        "@aws-sdk/token-providers": "3.388.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -481,13 +438,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
-      "integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.387.0.tgz",
+      "integrity": "sha512-6ueMPl+J3KWv6ZaAWF4Z138QCuBVFZRVAgwbtP3BNqWrrs4Q6TPksOQJ79lRDMpv0EUoyVl04B6lldNlhN8RdA==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -495,14 +452,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.378.0.tgz",
-      "integrity": "sha512-3o+AYU6JWUsPM49bWglCUOgNvySiHkbIma0J6F9a68e30vEDD0FUQtKzyHPZkF7iYDyesEl166gYjwVNAmASzw==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.387.0.tgz",
+      "integrity": "sha512-o7Dsq0YTUHFcKXD6+30/fXv/Wzdxqz9WonhCu3ZFPwTDLZgOM4QDDKW8EcC1SplKP1IUyaEli8Affodag9T1cQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-config-provider": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -595,13 +552,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.378.0.tgz",
-      "integrity": "sha512-8maaNQvza3/IGDbIyVQkUbGlo+Oc6SY1gVG50UMcTUX8nwZrD1/ko+ft+pd2EDb2n+0JritoDj4bjr6pdesNBg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.387.0.tgz",
+      "integrity": "sha512-w415a4tjQc6a7isq0AEDWFBC0HWUCHXEDjDl94UACxfMmS9bVabuf04t9CQ+nBBVs6HdiNdfdc/pBR2pRwx2Yg==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -609,16 +566,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.383.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.383.0.tgz",
-      "integrity": "sha512-RxIuby6Nz4pgKqNtt9Rdr2gWtOLrl9shZrteVuPh42n/dSOtCIhsG0fffKqy247I6oUghicoVJK9v0mxfINu/w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.387.0.tgz",
+      "integrity": "sha512-QlH97rrKlcMyLG+2ps7+DtBHfPyRIpi7sD3y0iko2u3PGXk+PoLPK8wWyGql9sFopOYTl6/Jh2Rb1b6z6NbjEA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -627,13 +584,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
-      "integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.387.0.tgz",
+      "integrity": "sha512-EWm9PXSr8dSp7hnRth1U7OfelXQp9dLf1yS1kUL+UhppYDJpjhdP7ql3NI4xJKw8e76sP2FuJYEuzWnJHuWoyQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -641,12 +598,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.379.1.tgz",
-      "integrity": "sha512-+bmy8DjX9jtqJk8WiDaHoP9M5ZcqjHSJf4mkv8IUZ/FNTUl9j6Dll//bG/JxuAw5e5shtCDjmZ027W5d9ITp0g==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.387.0.tgz",
+      "integrity": "sha512-Ipdry2V58CpDcWD0ZTz6yFtpTASEBxbuWdqUUYW7pOkZ/5GPGH8NhBky7M38iGqAO6FNysvWEVCUpIqNGkI1lw==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -654,12 +611,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
-      "integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.387.0.tgz",
+      "integrity": "sha512-FjAvJr1XyaInT81RxUwgifnbXoFJrRBFc64XeFJgFanGIQCWLYxRrK2HV9eBpao/AycbmuoHgLd/f0sa4hZFoQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -667,13 +624,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
-      "integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.387.0.tgz",
+      "integrity": "sha512-ZF45T785ru8OwvYZw6awD9Z76OwSMM1eZzj2eY+FDz1cHfkpLjxEiti2iIH1FxbyK7n9ZqDUx29lVlCv238YyQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -681,14 +638,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.379.1.tgz",
-      "integrity": "sha512-NVHRpNLfkHCqr3CE1Bmlf8Fhys8lL78kDX7UONnTZXvSiSXmCS7EbNtGDghZ8IKi+V9S/ifB4sLsX3tfzY0i6Q==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.387.0.tgz",
+      "integrity": "sha512-OIUBDzGhglI6KjXVwPLh7hRbrfCpSTwWRkbXbLrPgZZuzWMoJJ3q59RVkpLnAV9Mdkg6+YA6JTw4k4hcmJblVw==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -696,13 +653,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
-      "integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.387.0.tgz",
+      "integrity": "sha512-7ZzRKOJ4V/JDQmKz9z+FjZqw59mrMATEMLR6ff0H0JHMX0Uk5IX8TQB058ss+ar14qeJ4UcteYzCqHNI0O1BHw==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -710,15 +667,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
-      "integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.387.0.tgz",
+      "integrity": "sha512-oJXlE0MES8gxNLo137PPNNiOICQGOaETTvq3kBSJgb/gtEAxQajMIlaNT7s1wsjOAruFHt4975nCXuY4lpx7GQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -727,12 +684,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.378.0.tgz",
-      "integrity": "sha512-WDT2LOd6OxlY1zkrRG9ZtW2vFms/dsqMg9VyE88RKG2oATxSXEhkr5zLbNVh3TyuUKnV9jydate56d/ECwHOHg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.387.0.tgz",
+      "integrity": "sha512-Jtie1gqqcs7ZuYDlz/kuI3CKCXoCL5Ov/Gj5X8/XmwrQJEpuB6z0KY5H1qY0xo+jtAhC8nDPv0GnuLoOfn85hw==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -740,14 +697,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.382.0.tgz",
-      "integrity": "sha512-LFRW1jmXOrOAd3911ktn6oaYmuurNnulbdRMOUdwz99GGdLVFipQhOi9idKswb8IOhPa4jEVQt25Kcv7ctvu0A==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.387.0.tgz",
+      "integrity": "sha512-hTfFTwDtp86xS98BKa+RFuLfcvGftxwzrbZeisZV8hdb4ZhvNXjSxnvM3vetW0GUEnY9xHPSGyp2ERRTinPKFQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -791,14 +748,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.378.0.tgz",
-      "integrity": "sha512-gtuABS7EeYZQeNzTrabY3Ruv4wWmoz4u8OMSGl47gYPDWA70WYEZ0aoi4zSGuKhXiqtVvTsO9wGEMIInwV5phQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.387.0.tgz",
+      "integrity": "sha512-SGuUbEFi8BXYVv4M7Hc0488I7uZbTVBW19j/B7bnyfbKFrndBXM366s/mChx4iELtESQ61AAstyafx5nGj5tIg==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1002,15 +959,44 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.388.0.tgz",
+      "integrity": "sha512-2lo1gFJl624kfjo/YdU6zW+k6dEwhoqjNkDNbOZEFgS1KDofHe9GX8W4/ReKb0Ggho5/EcjzZ53/1CjkzUq4tA==",
       "dependencies": {
-        "@aws-sdk/client-sso-oidc": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
         "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1018,11 +1004,11 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
-      "integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
+      "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1041,11 +1027,11 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.382.0.tgz",
-      "integrity": "sha512-flajPyjmjNG67fXk7l4GoTB/7J11VBqtFZXuuAZKhKU07Ia3IQupsFqNf5lV8D44ZgjnKH0fTGnv3dUALjW7Wg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.387.0.tgz",
+      "integrity": "sha512-g7kvuCXehGXHHBw9PkSQdwVyDFmNUZLmfrRmqMyrMDG9QLQrxr4pyWcSaYgTE16yUzhQQOR+QSey+BL6W9/N6g==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1064,24 +1050,24 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
-      "integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.387.0.tgz",
+      "integrity": "sha512-lpgSVvDqx+JjHZCTYs/yQSS7J71dPlJeAlvxc7bmx5m+vfwKe07HAnIs+929DngS0QbAp/VaXbTiMFsInLkO4Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
-      "integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.387.0.tgz",
+      "integrity": "sha512-r9OVkcWpRYatjLhJacuHFgvO2T5s/Nu5DDbScMrkUD8b4aGIIqsrdZji0vZy9FCjsUFQMM92t9nt4SejrGjChA==",
       "dependencies": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1429,11 +1415,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1488,54 +1474,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.11.tgz",
-      "integrity": "sha512-q4qlUf5ucwbUJZXF5tEQ8LF7y0Nk4P58hOsGk3ucY0oCwgQqAnqXVbUuahCddVHfrxmpyewRpiTHwVHIETYu7Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.11.tgz",
-      "integrity": "sha512-snieiq75Z1z5LJX9cduSAjUr7vEI1OdlzFPMw0HH5YI7qQHDd3qs+WZoMrWYDsfRJSq36lIA6mfZBkvL46KoIw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.11.tgz",
-      "integrity": "sha512-iPuoxQEV34+hTF6FT7om+Qwziv1U519lEOvekXO9zaMMlT9+XneAhKL32DW3H7okrCOBQ44BMihE8dclbZtTuw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.11.tgz",
@@ -1547,294 +1485,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.11.tgz",
-      "integrity": "sha512-N15Vzy0YNHu6cfyDOjiyfJlRJCB/ngKOAvoBf1qybG3eOq0SL2Lutzz9N7DYUbb7Q23XtHPn6lMDF6uWbGv9Fw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.11.tgz",
-      "integrity": "sha512-atEyuq6a3omEY5qAh5jIORWk8MzFnCpSTUruBgeyN9jZq1K/QI9uke0ATi3MHu4L8c59CnIi4+1jDKMuqmR71A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.11.tgz",
-      "integrity": "sha512-XtuPrEfBj/YYYnAAB7KcorzzpGTvOr/dTtXPGesRfmflqhA4LMF0Gh/n5+a9JBzPuJ+CGk17CA++Hmr1F/gI0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.11.tgz",
-      "integrity": "sha512-Idipz+Taso/toi2ETugShXjQ3S59b6m62KmLHkJlSq/cBejixmIydqrtM2XTvNCywFl3VC7SreSf6NV0i6sRyg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.11.tgz",
-      "integrity": "sha512-c6Vh2WS9VFKxKZ2TvJdA7gdy0n6eSy+yunBvv4aqNCEhSWVor1TU43wNRp2YLO9Vng2G+W94aRz+ILDSwAiYog==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.11.tgz",
-      "integrity": "sha512-S3hkIF6KUqRh9n1Q0dSyYcWmcVa9Cg+mSoZEfFuzoYXXsk6196qndrM+ZiHNwpZKi3XOXpShZZ+9dfN5ykqjjw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.11.tgz",
-      "integrity": "sha512-MRESANOoObQINBA+RMZW+Z0TJWpibtE7cPFnahzyQHDCA9X9LOmGh68MVimZlM9J8n5Ia8lU773te6O3ILW8kw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.11.tgz",
-      "integrity": "sha512-qVyPIZrXNMOLYegtD1u8EBccCrBVshxMrn5MkuFc3mEVsw7CCQHaqZ4jm9hbn4gWY95XFnb7i4SsT3eflxZsUg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.11.tgz",
-      "integrity": "sha512-T3yd8vJXfPirZaUOoA9D2ZjxZX4Gr3QuC3GztBJA6PklLotc/7sXTOuuRkhE9W/5JvJP/K9b99ayPNAD+R+4qQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.11.tgz",
-      "integrity": "sha512-evUoRPWiwuFk++snjH9e2cAjF5VVSTj+Dnf+rkO/Q20tRqv+644279TZlPK8nUGunjPAtQRCj1jQkDAvL6rm2w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.11.tgz",
-      "integrity": "sha512-/SlRJ15XR6i93gRWquRxYCfhTeC5PdqEapKoLbX63PLCmAkXZHY2uQm2l9bN0oPHBsOw2IswRZctMYS0MijFcg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.11.tgz",
-      "integrity": "sha512-xcncej+wF16WEmIwPtCHi0qmx1FweBqgsRtEL1mSHLFR6/mb3GEZfLQnx+pUDfRDEM4DQF8dpXIW7eDOZl1IbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.11.tgz",
-      "integrity": "sha512-aSjMHj/F7BuS1CptSXNg6S3M4F3bLp5wfFPIJM+Km2NfIVfFKhdmfHF9frhiCLIGVzDziggqWll0B+9AUbud/Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.11.tgz",
-      "integrity": "sha512-tNBq+6XIBZtht0xJGv7IBB5XaSyvYPCm1PxJ33zLQONdZoLVM0bgGqUrXnJyiEguD9LU4AHiu+GCXy/Hm9LsdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.11.tgz",
-      "integrity": "sha512-kxfbDOrH4dHuAAOhr7D7EqaYf+W45LsAOOhAet99EyuxxQmjbk8M9N4ezHcEiCYPaiW8Dj3K26Z2V17Gt6p3ng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.11.tgz",
-      "integrity": "sha512-Sh0dDRyk1Xi348idbal7lZyfSkjhJsdFeuC13zqdipsvMetlGiFQNdO+Yfp6f6B4FbyQm7qsk16yaZk25LChzg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.11.tgz",
-      "integrity": "sha512-o9JUIKF1j0rqJTFbIoF4bXj6rvrTZYOrfRcGyL0Vm5uJ/j5CkBD/51tpdxe9lXEDouhRgdr/BYzUrDOvrWwJpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.11.tgz",
-      "integrity": "sha512-rQI4cjLHd2hGsM1LqgDI7oOCYbQ6IBOVsX9ejuRMSze0GqXUG2ekwiKkiBU1pRGSeCqFFHxTrcEydB2Hyoz9CA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -2037,7 +1687,7 @@
     "node_modules/@opentdf/client": {
       "version": "1.2.2",
       "resolved": "file:../lib/opentdf-client-1.2.2.tgz",
-      "integrity": "sha512-Y6PK8lCQpKLs9GvhXDwoHE/W5MeQunIbf7uPE91sWpBFU5I2kE9NZQ5cE4LzENwfZKY8ZxHEKZqjM+PmV6xEig==",
+      "integrity": "sha512-2Z/jYDq3+GLrv21U/pG8968Webgn0IbZmYolTJ+bvcVTaVsRco59OEe0A+Vvj0Relp8QNsp+Yh6qsa1orWb/cw==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/abort-controller": "^3.370.0",
@@ -2194,11 +1844,11 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-      "integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
+      "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2208,14 +1858,14 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-      "integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
+      "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2223,23 +1873,23 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
-      "integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz",
+      "integrity": "sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.1.tgz",
-      "integrity": "sha512-9E1/6ZGF7nB/Td3G1kcatU7VjjP8eZ/p/Q+0KsZc1AUPyv4lR15pmWnWj3iGBEGYI9qZBJ/7a/wPEPayabmA3Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.2.tgz",
+      "integrity": "sha512-qaHlcFI+ILE+gZV2B/aZMVXc9LG4v1Owa20dHlP0dLOiJ9WByOjtD2qZmYA/HO4qkkDZHEL/0baWc63aqLCHKQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-serde-universal": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2247,11 +1897,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.1.tgz",
-      "integrity": "sha512-J8a+8HH8oDPIgq8Px/nPLfu9vpIjQ7XUPtP3orbs8KUh0GznNthSTy1xZP5RXjRqGQEkxPvsHf1po2+QOsgNFw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.2.tgz",
+      "integrity": "sha512-iVC7/NFNWfSXllAxFNUuC4QlREdZjMmAOdISb6fwny/4mUDt1EtYLCrXq7gN1mIzhRPwMpL9YvQ8jpgvfA0Jdw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2259,12 +1909,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.1.tgz",
-      "integrity": "sha512-wklowUz0zXJuqC7FMpriz66J8OAko3z6INTg+iMJWYB1bWv4pc5V7q36PxlZ0RKRbj0u+EThlozWgzE7Stz2Sw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.2.tgz",
+      "integrity": "sha512-p7py8jDpIS1bRewskwgEgJx1OkFvockA2bJnXtOAPJib42DtyRpp8oV14s2ZpjMq57r9KMCQy2j02g554DNavg==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-serde-universal": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2272,12 +1922,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.1.tgz",
-      "integrity": "sha512-WPPylIgVZ6wOYVgpF0Rs1LlocYyj248MRtKEEehnDvC+0tV7wmGt7H/SchCh10W4y4YUxuzPlW+mUvVMGmLSVg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.2.tgz",
+      "integrity": "sha512-zf/hm5VIDsvl+XpI1rop4xwXLKiBUe5pxgjRFdHi7AC1p6Zc8uJfyCExLiMUP/QspoIrVV1xGwFFxRCeddDH3g==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-codec": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2285,34 +1935,34 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-      "integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
+      "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.1.tgz",
-      "integrity": "sha512-i/o2+sHb4jDRz5nf2ilTTbC0nVmm4LO//FbODCAB7pbzMdywxbZ6z+q56FmEa8R+aFbtApxQ1SJ3umEiNz6IPg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.2.tgz",
+      "integrity": "sha512-CmVGWbiyiEySGDRg3o2C3DLZYW+mH8fMoIEZrmwnBM8bQsepZGOME40tbpvv12BIhZIInJV8srMMHpQ6aKObLA==",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^2.0.0",
         "@smithy/chunked-blob-reader-native": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-      "integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2322,11 +1972,11 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.1.tgz",
-      "integrity": "sha512-AequnQdPRuXf4AuvvFlSjnkWI460xxhAd6y362gFtOE4jjJLLXblbMAXVFrkV8/pDMGNjpVegVSpRmHXZsbKhg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.2.tgz",
+      "integrity": "sha512-cDfGE81BbykXKZ50+eLU5Yat8WGiDFQpNa+5S3AfDIzz5h4D73DpxWwcwV4qYB7GoAw2chFqTCAGWgU/MgRS9g==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2335,11 +1985,11 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-      "integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
+      "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2355,22 +2005,22 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.1.tgz",
-      "integrity": "sha512-8WWOtwWMmIDgTkRv1o3opy3ABsRXs4/XunETK53ckxQRAiOML1PlnqLBK9Uwk9bvOD6cpmsC6dioIfmKGpJ25w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.2.tgz",
+      "integrity": "sha512-qm9845tzkYOm3HM/nFiZVMsA9nE7klO69T1qrrbrQKpUJpEFV87XDInbnRpYzBAFUH4DRodbZ9spEnjF7ffoww==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-      "integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
+      "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2378,13 +2028,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-      "integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
+      "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2393,13 +2043,13 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-      "integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
+      "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
       "dependencies": {
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
@@ -2418,11 +2068,11 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-      "integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
+      "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2441,13 +2091,13 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-      "integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
+      "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/shared-ini-file-loader": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2455,14 +2105,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-      "integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
+      "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2470,11 +2120,11 @@
       }
     },
     "node_modules/@smithy/node-http-handler/node_modules/@smithy/abort-controller": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-      "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+      "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2482,11 +2132,11 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-      "integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
+      "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2494,11 +2144,11 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
-      "integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2506,11 +2156,11 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-      "integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
+      "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       },
@@ -2519,11 +2169,11 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-      "integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2539,11 +2189,11 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-      "integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
+      "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2551,13 +2201,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
-      "integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.2.tgz",
+      "integrity": "sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.1",
+        "@smithy/eventstream-codec": "^2.0.2",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -2569,13 +2219,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-      "integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
+      "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.0.2",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-stream": "^2.0.2",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2583,9 +2233,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2594,12 +2244,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-      "integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/querystring-parser": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -2658,12 +2308,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-      "integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
+      "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       },
@@ -2672,15 +2322,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-      "integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
+      "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/credential-provider-imds": "^2.0.1",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/credential-provider-imds": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2722,13 +2372,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-      "integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
+      "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -2763,12 +2413,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.1.tgz",
-      "integrity": "sha512-bSyGFicPRYuGFFWAr72UvYI7tE7KmEeFJJ5iaLuTTdo8RGaNBZ2kE25coGtzrejYh9AhwSfckBvbxgEDxIxhlA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.2.tgz",
+      "integrity": "sha512-7XCEVXDLguf3Og0NIF/KYEAHtrzNXmCdtEwMfOXr4iBKOUWYzNj91YB9O7tLrct8VGvysGA0x2xYzbxMbvF0QQ==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -2776,11 +2426,11 @@
       }
     },
     "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-      "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+      "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
       "dependencies": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -5254,9 +4904,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -6176,184 +5826,144 @@
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.383.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.383.0.tgz",
-      "integrity": "sha512-8x3WtuGHy3mESB3UxbZKdrZgMDBqqyPdUGwnkM8YeC8VkGce5pS98OgYe350aUNSzTkE3dNipzYZtm2BjalAyA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.388.0.tgz",
+      "integrity": "sha512-9UN8gtr/4e4YnHb3Kb4VsxGTDe6olkL90ivK09jKwG2SX8m5OY2fIHSjtyqUHDuFb67JOk3WVEMbZEfxfx46+w==",
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.382.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.378.0",
-        "@aws-sdk/middleware-expect-continue": "3.378.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.383.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-location-constraint": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-sdk-s3": "3.379.1",
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-ssec": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/signature-v4-multi-region": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
+        "@aws-sdk/client-sts": "3.388.0",
+        "@aws-sdk/credential-provider-node": "3.388.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.387.0",
+        "@aws-sdk/middleware-expect-continue": "3.387.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.387.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-location-constraint": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-sdk-s3": "3.387.0",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/middleware-ssec": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/signature-v4-multi-region": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
         "@aws-sdk/xml-builder": "3.310.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/eventstream-serde-browser": "^2.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^2.0.1",
-        "@smithy/eventstream-serde-node": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-blob-browser": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/hash-stream-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/md5-js": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/eventstream-serde-browser": "^2.0.2",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.2",
+        "@smithy/eventstream-serde-node": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-blob-browser": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/hash-stream-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/md5-js": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/util-stream": "^2.0.2",
         "@smithy/util-utf8": "^2.0.0",
-        "@smithy/util-waiter": "^2.0.1",
+        "@smithy/util-waiter": "^2.0.2",
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.382.0.tgz",
-      "integrity": "sha512-ge11t4hJllOF8pBNF0p1X52lLqUsLGAoey24fvk3fyvvczeLpegGYh2kdLG0iwFTDgRxaUqK+kboH5Wy9ux/pw==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.387.0.tgz",
+      "integrity": "sha512-E7uKSvbA0XMKSN5KLInf52hmMpe9/OKo6N9OPffGXdn3fNEQlvyQq3meUkqG7Is0ldgsQMz5EUBNtNybXzr3tQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
-        "@smithy/util-retry": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@aws-sdk/client-sso-oidc": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.382.0.tgz",
-      "integrity": "sha512-hTfvB1ftbrqaz7qiEkmRobzUQwG34oZlByobn8Frdr5ZQbJk969bX6evQAPyKlJEr26+kL9TnaX+rbLR/+gwHQ==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.382.0.tgz",
-      "integrity": "sha512-G5wgahrOqmrljjyLVGASIZUXIIdalbCo0z4PuFHdb2R2CVfwO8renfgrmk4brT9tIxIfen5bRA7ftXMe7yrgRA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.388.0.tgz",
+      "integrity": "sha512-y9FAcAYHT8O6T/jqhgsIQUb4gLiSTKD3xtzudDvjmFi8gl0oRIY1npbeckSiK6k07VQugm2s64I0nDnDxtWsBg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.382.0",
-        "@aws-sdk/middleware-host-header": "3.379.1",
-        "@aws-sdk/middleware-logger": "3.378.0",
-        "@aws-sdk/middleware-recursion-detection": "3.378.0",
-        "@aws-sdk/middleware-sdk-sts": "3.379.1",
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/middleware-user-agent": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@aws-sdk/util-user-agent-browser": "3.378.0",
-        "@aws-sdk/util-user-agent-node": "3.378.0",
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/hash-node": "^2.0.1",
-        "@smithy/invalid-dependency": "^2.0.1",
-        "@smithy/middleware-content-length": "^2.0.1",
-        "@smithy/middleware-endpoint": "^2.0.1",
-        "@smithy/middleware-retry": "^2.0.1",
-        "@smithy/middleware-serde": "^2.0.1",
+        "@aws-sdk/credential-provider-node": "3.388.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-sdk-sts": "3.387.0",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/smithy-client": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-body-length-browser": "^2.0.0",
         "@smithy/util-body-length-node": "^2.0.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.1",
-        "@smithy/util-defaults-mode-node": "^2.0.1",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
         "@smithy/util-retry": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "fast-xml-parser": "4.2.5",
@@ -6361,97 +5971,97 @@
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.378.0.tgz",
-      "integrity": "sha512-B2OVdO9kBClDwGgWTBLAQwFV8qYTYGyVujg++1FZFSFMt8ORFdZ5fNpErvJtiSjYiOOQMzyBeSNhKyYNXCiJjQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.387.0.tgz",
+      "integrity": "sha512-PVqNk7XPIYe5CMYNvELkcALtkl/pIM8/uPtqEtTg+mgnZBeL4fAmgXZiZMahQo1DxP5t/JaK384f6JG+A0qDjA==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.382.0.tgz",
-      "integrity": "sha512-31pi44WWri2WQmagqptUv7x3Nq8pQ6H06OCQx5goEm77SosSdwQwyBPrS9Pg0yI9aljFAxF+rZ75degsCorbQg==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.388.0.tgz",
+      "integrity": "sha512-3dg3A8AiZ5vXkSAYyyI3V/AW3Eo6KQJyE/glA+Nr2M0oAjT4z3vHhS3pf2B+hfKGZBTuKKgxusrrhrQABd/Diw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
-        "@aws-sdk/credential-provider-web-identity": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/credential-provider-env": "3.387.0",
+        "@aws-sdk/credential-provider-process": "3.387.0",
+        "@aws-sdk/credential-provider-sso": "3.388.0",
+        "@aws-sdk/credential-provider-web-identity": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.382.0.tgz",
-      "integrity": "sha512-q6AWCCb0E0cH/Y5Dtln0QssbCBXDbV4PoTV3EdRuGoJcHyNfHJ8X0mqcc7k44wG4Piazu+ufZThvn43W7W9a4g==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.388.0.tgz",
+      "integrity": "sha512-BqWAkIG08gj/wevpesaZhAjALjfUNVjseHQRk+DNUoHIfyibW7Ahf3q/GIPs11dA2o8ECwR9/fo68Sq+sK799A==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.378.0",
-        "@aws-sdk/credential-provider-ini": "3.382.0",
-        "@aws-sdk/credential-provider-process": "3.378.0",
-        "@aws-sdk/credential-provider-sso": "3.382.0",
-        "@aws-sdk/credential-provider-web-identity": "3.378.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/credential-provider-env": "3.387.0",
+        "@aws-sdk/credential-provider-ini": "3.388.0",
+        "@aws-sdk/credential-provider-process": "3.387.0",
+        "@aws-sdk/credential-provider-sso": "3.388.0",
+        "@aws-sdk/credential-provider-web-identity": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/credential-provider-imds": "^2.0.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.378.0.tgz",
-      "integrity": "sha512-KFTIy7u+wXj3eDua4rgS0tODzMnXtXhAm1RxzCW9FL5JLBBrd82ymCj1Dp72217Sw5Do6NjCnDTTNkCHZMA77w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.387.0.tgz",
+      "integrity": "sha512-tQScLHmDlqkQN+mqw4s3cxepEUeHYDhFl5eH+J8puvPqWjXMYpCEdY79SAtWs6SZd4CWiZ0VLeYU6xQBZengbQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.382.0.tgz",
-      "integrity": "sha512-tKCQKqxnAHeRD7pQNmDmLWwC7pt5koo6yiQTVQ382U+8xx7BNsApE1zdC4LrtrVN1FYqVbw5kXjYFtSCtaUxGA==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.388.0.tgz",
+      "integrity": "sha512-RH02+rntaO0UhnSBr42n+7q8HOztc+Dets/hh6cWovf3Yi9s9ghLgYLN9FXpSosfot3XkmT/HOCa+CphAmGN9A==",
       "requires": {
-        "@aws-sdk/client-sso": "3.382.0",
-        "@aws-sdk/token-providers": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/client-sso": "3.387.0",
+        "@aws-sdk/token-providers": "3.388.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.378.0.tgz",
-      "integrity": "sha512-GWjydOszhc4xDF8xuPtBvboglXQr0gwCW1oHAvmLcOT38+Hd6qnKywnMSeoXYRPgoKfF9TkWQgW1jxplzCG0UA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.387.0.tgz",
+      "integrity": "sha512-6ueMPl+J3KWv6ZaAWF4Z138QCuBVFZRVAgwbtP3BNqWrrs4Q6TPksOQJ79lRDMpv0EUoyVl04B6lldNlhN8RdA==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.378.0.tgz",
-      "integrity": "sha512-3o+AYU6JWUsPM49bWglCUOgNvySiHkbIma0J6F9a68e30vEDD0FUQtKzyHPZkF7iYDyesEl166gYjwVNAmASzw==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.387.0.tgz",
+      "integrity": "sha512-o7Dsq0YTUHFcKXD6+30/fXv/Wzdxqz9WonhCu3ZFPwTDLZgOM4QDDKW8EcC1SplKP1IUyaEli8Affodag9T1cQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-config-provider": "^2.0.0",
         "tslib": "^2.5.0"
       }
@@ -6524,129 +6134,129 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.378.0.tgz",
-      "integrity": "sha512-8maaNQvza3/IGDbIyVQkUbGlo+Oc6SY1gVG50UMcTUX8nwZrD1/ko+ft+pd2EDb2n+0JritoDj4bjr6pdesNBg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.387.0.tgz",
+      "integrity": "sha512-w415a4tjQc6a7isq0AEDWFBC0HWUCHXEDjDl94UACxfMmS9bVabuf04t9CQ+nBBVs6HdiNdfdc/pBR2pRwx2Yg==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.383.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.383.0.tgz",
-      "integrity": "sha512-RxIuby6Nz4pgKqNtt9Rdr2gWtOLrl9shZrteVuPh42n/dSOtCIhsG0fffKqy247I6oUghicoVJK9v0mxfINu/w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.387.0.tgz",
+      "integrity": "sha512-QlH97rrKlcMyLG+2ps7+DtBHfPyRIpi7sD3y0iko2u3PGXk+PoLPK8wWyGql9sFopOYTl6/Jh2Rb1b6z6NbjEA==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.379.1.tgz",
-      "integrity": "sha512-LI4KpAFWNWVr2aH2vRVblr0Y8tvDz23lj8LOmbDmCrzd5M21nxuocI/8nEAQj55LiTIf9Zs+dHCdsyegnFXdrA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.387.0.tgz",
+      "integrity": "sha512-EWm9PXSr8dSp7hnRth1U7OfelXQp9dLf1yS1kUL+UhppYDJpjhdP7ql3NI4xJKw8e76sP2FuJYEuzWnJHuWoyQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-location-constraint": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.379.1.tgz",
-      "integrity": "sha512-+bmy8DjX9jtqJk8WiDaHoP9M5ZcqjHSJf4mkv8IUZ/FNTUl9j6Dll//bG/JxuAw5e5shtCDjmZ027W5d9ITp0g==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.387.0.tgz",
+      "integrity": "sha512-Ipdry2V58CpDcWD0ZTz6yFtpTASEBxbuWdqUUYW7pOkZ/5GPGH8NhBky7M38iGqAO6FNysvWEVCUpIqNGkI1lw==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.378.0.tgz",
-      "integrity": "sha512-l1DyaDLm3KeBMNMuANI3scWh8Xvu248x+vw6Z7ExWOhGXFmQ1MW7YvASg/SdxWkhlF9HmkkTif1LdMB22x6QDA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.387.0.tgz",
+      "integrity": "sha512-FjAvJr1XyaInT81RxUwgifnbXoFJrRBFc64XeFJgFanGIQCWLYxRrK2HV9eBpao/AycbmuoHgLd/f0sa4hZFoQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.378.0.tgz",
-      "integrity": "sha512-mUMfHAz0oGNIWiTZHTVJb+I515Hqs2zx1j36Le4MMiiaMkPW1SRUF1FIwGuc1wh6E8jB5q+XfEMriDjRi4TZRA==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.387.0.tgz",
+      "integrity": "sha512-ZF45T785ru8OwvYZw6awD9Z76OwSMM1eZzj2eY+FDz1cHfkpLjxEiti2iIH1FxbyK7n9ZqDUx29lVlCv238YyQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.379.1.tgz",
-      "integrity": "sha512-NVHRpNLfkHCqr3CE1Bmlf8Fhys8lL78kDX7UONnTZXvSiSXmCS7EbNtGDghZ8IKi+V9S/ifB4sLsX3tfzY0i6Q==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.387.0.tgz",
+      "integrity": "sha512-OIUBDzGhglI6KjXVwPLh7hRbrfCpSTwWRkbXbLrPgZZuzWMoJJ3q59RVkpLnAV9Mdkg6+YA6JTw4k4hcmJblVw==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@aws-sdk/util-arn-parser": "3.310.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.379.1.tgz",
-      "integrity": "sha512-SK3gSyT0XbLiY12+AjLFYL9YngxOXHnZF3Z33Cdd4a+AUYrVBV7JBEEGD1Nlwrcmko+3XgaKlmgUaR5s91MYvg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.387.0.tgz",
+      "integrity": "sha512-7ZzRKOJ4V/JDQmKz9z+FjZqw59mrMATEMLR6ff0H0JHMX0Uk5IX8TQB058ss+ar14qeJ4UcteYzCqHNI0O1BHw==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.379.1",
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/middleware-signing": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.379.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.379.1.tgz",
-      "integrity": "sha512-kBk2ZUvR84EM4fICjr8K+Ykpf8SI1UzzPp2/UVYZ0X+4H/ZCjfSqohGRwHykMqeplne9qHSL7/rGJs1H3l3gPg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.387.0.tgz",
+      "integrity": "sha512-oJXlE0MES8gxNLo137PPNNiOICQGOaETTvq3kBSJgb/gtEAxQajMIlaNT7s1wsjOAruFHt4975nCXuY4lpx7GQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-ssec": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.378.0.tgz",
-      "integrity": "sha512-WDT2LOd6OxlY1zkrRG9ZtW2vFms/dsqMg9VyE88RKG2oATxSXEhkr5zLbNVh3TyuUKnV9jydate56d/ECwHOHg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.387.0.tgz",
+      "integrity": "sha512-Jtie1gqqcs7ZuYDlz/kuI3CKCXoCL5Ov/Gj5X8/XmwrQJEpuB6z0KY5H1qY0xo+jtAhC8nDPv0GnuLoOfn85hw==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.382.0.tgz",
-      "integrity": "sha512-LFRW1jmXOrOAd3911ktn6oaYmuurNnulbdRMOUdwz99GGdLVFipQhOi9idKswb8IOhPa4jEVQt25Kcv7ctvu0A==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.387.0.tgz",
+      "integrity": "sha512-hTfFTwDtp86xS98BKa+RFuLfcvGftxwzrbZeisZV8hdb4ZhvNXjSxnvM3vetW0GUEnY9xHPSGyp2ERRTinPKFQ==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@aws-sdk/util-endpoints": "3.382.0",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6679,14 +6289,14 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.378.0.tgz",
-      "integrity": "sha512-gtuABS7EeYZQeNzTrabY3Ruv4wWmoz4u8OMSGl47gYPDWA70WYEZ0aoi4zSGuKhXiqtVvTsO9wGEMIInwV5phQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.387.0.tgz",
+      "integrity": "sha512-SGuUbEFi8BXYVv4M7Hc0488I7uZbTVBW19j/B7bnyfbKFrndBXM366s/mChx4iELtESQ61AAstyafx5nGj5tIg==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/protocol-http": "^2.0.1",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6838,24 +6448,53 @@
       }
     },
     "@aws-sdk/token-providers": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.382.0.tgz",
-      "integrity": "sha512-axn4IyPpHdkXi8G06KCB3tPz79DipZFFH9N9YVDpLMnDYTdfX36HGdYzINaQc+z+XPbEpa1ZpoIzWScHRjFjdg==",
+      "version": "3.388.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.388.0.tgz",
+      "integrity": "sha512-2lo1gFJl624kfjo/YdU6zW+k6dEwhoqjNkDNbOZEFgS1KDofHe9GX8W4/ReKb0Ggho5/EcjzZ53/1CjkzUq4tA==",
       "requires": {
-        "@aws-sdk/client-sso-oidc": "3.382.0",
-        "@aws-sdk/types": "3.378.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.387.0",
+        "@aws-sdk/middleware-logger": "3.387.0",
+        "@aws-sdk/middleware-recursion-detection": "3.387.0",
+        "@aws-sdk/middleware-user-agent": "3.387.0",
+        "@aws-sdk/types": "3.387.0",
+        "@aws-sdk/util-endpoints": "3.387.0",
+        "@aws-sdk/util-user-agent-browser": "3.387.0",
+        "@aws-sdk/util-user-agent-node": "3.387.0",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/hash-node": "^2.0.2",
+        "@smithy/invalid-dependency": "^2.0.2",
+        "@smithy/middleware-content-length": "^2.0.2",
+        "@smithy/middleware-endpoint": "^2.0.2",
+        "@smithy/middleware-retry": "^2.0.2",
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/middleware-stack": "^2.0.0",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
         "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/shared-ini-file-loader": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/smithy-client": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.0.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.2",
+        "@smithy/util-defaults-mode-node": "^2.0.2",
+        "@smithy/util-retry": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.378.0.tgz",
-      "integrity": "sha512-qP0CvR/ItgktmN8YXpGQglzzR/6s0nrsQ4zIfx3HMwpsBTwuouYahcCtF1Vr82P4NFcoDA412EJahJ2pIqEd+w==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.387.0.tgz",
+      "integrity": "sha512-YTjFabNwjTF+6yl88f0/tWff018qmmgMmjlw45s6sdVKueWxdxV68U7gepNLF2nhaQPZa6FDOBoA51NaviVs0Q==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6868,11 +6507,11 @@
       }
     },
     "@aws-sdk/util-endpoints": {
-      "version": "3.382.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.382.0.tgz",
-      "integrity": "sha512-flajPyjmjNG67fXk7l4GoTB/7J11VBqtFZXuuAZKhKU07Ia3IQupsFqNf5lV8D44ZgjnKH0fTGnv3dUALjW7Wg==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.387.0.tgz",
+      "integrity": "sha512-g7kvuCXehGXHHBw9PkSQdwVyDFmNUZLmfrRmqMyrMDG9QLQrxr4pyWcSaYgTE16yUzhQQOR+QSey+BL6W9/N6g==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
+        "@aws-sdk/types": "3.387.0",
         "tslib": "^2.5.0"
       }
     },
@@ -6885,24 +6524,24 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.378.0.tgz",
-      "integrity": "sha512-FSCpagzftK1W+m7Ar6lpX7/Gr9y5P56nhFYz8U4EYQ4PkufS6czWX9YW+/FA5OYV0vlQ/SvPqMnzoHIPUNhZrQ==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.387.0.tgz",
+      "integrity": "sha512-lpgSVvDqx+JjHZCTYs/yQSS7J71dPlJeAlvxc7bmx5m+vfwKe07HAnIs+929DngS0QbAp/VaXbTiMFsInLkO4Q==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/types": "^2.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.378.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.378.0.tgz",
-      "integrity": "sha512-IdwVJV0E96MkJeFte4dlWqvB+oiqCiZ5lOlheY3W9NynTuuX0GGYNC8Y9yIsV8Oava1+ujpJq0ww6qXdYxmO4A==",
+      "version": "3.387.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.387.0.tgz",
+      "integrity": "sha512-r9OVkcWpRYatjLhJacuHFgvO2T5s/Nu5DDbScMrkUD8b4aGIIqsrdZji0vZy9FCjsUFQMM92t9nt4SejrGjChA==",
       "requires": {
-        "@aws-sdk/types": "3.378.0",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@aws-sdk/types": "3.387.0",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7152,11 +6791,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.10.tgz",
+      "integrity": "sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
@@ -7199,157 +6838,10 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@esbuild/android-arm": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.11.tgz",
-      "integrity": "sha512-q4qlUf5ucwbUJZXF5tEQ8LF7y0Nk4P58hOsGk3ucY0oCwgQqAnqXVbUuahCddVHfrxmpyewRpiTHwVHIETYu7Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.11.tgz",
-      "integrity": "sha512-snieiq75Z1z5LJX9cduSAjUr7vEI1OdlzFPMw0HH5YI7qQHDd3qs+WZoMrWYDsfRJSq36lIA6mfZBkvL46KoIw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.11.tgz",
-      "integrity": "sha512-iPuoxQEV34+hTF6FT7om+Qwziv1U519lEOvekXO9zaMMlT9+XneAhKL32DW3H7okrCOBQ44BMihE8dclbZtTuw==",
-      "dev": true,
-      "optional": true
-    },
     "@esbuild/darwin-arm64": {
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.11.tgz",
       "integrity": "sha512-Gm0QkI3k402OpfMKyQEEMG0RuW2LQsSmI6OeO4El2ojJMoF5NLYb3qMIjvbG/lbMeLOGiW6ooU8xqc+S0fgz2w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.11.tgz",
-      "integrity": "sha512-N15Vzy0YNHu6cfyDOjiyfJlRJCB/ngKOAvoBf1qybG3eOq0SL2Lutzz9N7DYUbb7Q23XtHPn6lMDF6uWbGv9Fw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.11.tgz",
-      "integrity": "sha512-atEyuq6a3omEY5qAh5jIORWk8MzFnCpSTUruBgeyN9jZq1K/QI9uke0ATi3MHu4L8c59CnIi4+1jDKMuqmR71A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.11.tgz",
-      "integrity": "sha512-XtuPrEfBj/YYYnAAB7KcorzzpGTvOr/dTtXPGesRfmflqhA4LMF0Gh/n5+a9JBzPuJ+CGk17CA++Hmr1F/gI0Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.11.tgz",
-      "integrity": "sha512-Idipz+Taso/toi2ETugShXjQ3S59b6m62KmLHkJlSq/cBejixmIydqrtM2XTvNCywFl3VC7SreSf6NV0i6sRyg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.11.tgz",
-      "integrity": "sha512-c6Vh2WS9VFKxKZ2TvJdA7gdy0n6eSy+yunBvv4aqNCEhSWVor1TU43wNRp2YLO9Vng2G+W94aRz+ILDSwAiYog==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.11.tgz",
-      "integrity": "sha512-S3hkIF6KUqRh9n1Q0dSyYcWmcVa9Cg+mSoZEfFuzoYXXsk6196qndrM+ZiHNwpZKi3XOXpShZZ+9dfN5ykqjjw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.11.tgz",
-      "integrity": "sha512-MRESANOoObQINBA+RMZW+Z0TJWpibtE7cPFnahzyQHDCA9X9LOmGh68MVimZlM9J8n5Ia8lU773te6O3ILW8kw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.11.tgz",
-      "integrity": "sha512-qVyPIZrXNMOLYegtD1u8EBccCrBVshxMrn5MkuFc3mEVsw7CCQHaqZ4jm9hbn4gWY95XFnb7i4SsT3eflxZsUg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.11.tgz",
-      "integrity": "sha512-T3yd8vJXfPirZaUOoA9D2ZjxZX4Gr3QuC3GztBJA6PklLotc/7sXTOuuRkhE9W/5JvJP/K9b99ayPNAD+R+4qQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.11.tgz",
-      "integrity": "sha512-evUoRPWiwuFk++snjH9e2cAjF5VVSTj+Dnf+rkO/Q20tRqv+644279TZlPK8nUGunjPAtQRCj1jQkDAvL6rm2w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.11.tgz",
-      "integrity": "sha512-/SlRJ15XR6i93gRWquRxYCfhTeC5PdqEapKoLbX63PLCmAkXZHY2uQm2l9bN0oPHBsOw2IswRZctMYS0MijFcg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.11.tgz",
-      "integrity": "sha512-xcncej+wF16WEmIwPtCHi0qmx1FweBqgsRtEL1mSHLFR6/mb3GEZfLQnx+pUDfRDEM4DQF8dpXIW7eDOZl1IbA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.11.tgz",
-      "integrity": "sha512-aSjMHj/F7BuS1CptSXNg6S3M4F3bLp5wfFPIJM+Km2NfIVfFKhdmfHF9frhiCLIGVzDziggqWll0B+9AUbud/Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.11.tgz",
-      "integrity": "sha512-tNBq+6XIBZtht0xJGv7IBB5XaSyvYPCm1PxJ33zLQONdZoLVM0bgGqUrXnJyiEguD9LU4AHiu+GCXy/Hm9LsdQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.11.tgz",
-      "integrity": "sha512-kxfbDOrH4dHuAAOhr7D7EqaYf+W45LsAOOhAet99EyuxxQmjbk8M9N4ezHcEiCYPaiW8Dj3K26Z2V17Gt6p3ng==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.11.tgz",
-      "integrity": "sha512-Sh0dDRyk1Xi348idbal7lZyfSkjhJsdFeuC13zqdipsvMetlGiFQNdO+Yfp6f6B4FbyQm7qsk16yaZk25LChzg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.11.tgz",
-      "integrity": "sha512-o9JUIKF1j0rqJTFbIoF4bXj6rvrTZYOrfRcGyL0Vm5uJ/j5CkBD/51tpdxe9lXEDouhRgdr/BYzUrDOvrWwJpg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.18.11",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.11.tgz",
-      "integrity": "sha512-rQI4cjLHd2hGsM1LqgDI7oOCYbQ6IBOVsX9ejuRMSze0GqXUG2ekwiKkiBU1pRGSeCqFFHxTrcEydB2Hyoz9CA==",
       "dev": true,
       "optional": true
     },
@@ -7491,7 +6983,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-1.2.2.tgz",
-      "integrity": "sha512-Y6PK8lCQpKLs9GvhXDwoHE/W5MeQunIbf7uPE91sWpBFU5I2kE9NZQ5cE4LzENwfZKY8ZxHEKZqjM+PmV6xEig==",
+      "integrity": "sha512-2Z/jYDq3+GLrv21U/pG8968Webgn0IbZmYolTJ+bvcVTaVsRco59OEe0A+Vvj0Relp8QNsp+Yh6qsa1orWb/cw==",
       "requires": {
         "@aws-sdk/abort-controller": "^3.370.0",
         "@aws-sdk/client-s3": "^3.379.1",
@@ -7611,128 +7103,128 @@
       }
     },
     "@smithy/config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.1.tgz",
-      "integrity": "sha512-l83Pm7hV+8CBQOCmBRopWDtF+CURUJol7NsuPYvimiDhkC2F8Ba9T1imSFE+pD1UIJ9jlsDPAnZfPJT5cjnuEw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.2.tgz",
+      "integrity": "sha512-0kdsqBL6BdmSbdU6YaDkodVBMua5MuQQluC3nocJ7OJ6PnOuM7i2FEQHE46LBadLqT+CimlDSM+6j91uHNL1ng==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-config-provider": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.1.tgz",
-      "integrity": "sha512-8VxriuRINNEfVZjEFKBY75y9ZWAx73DZ5K/u+3LmB6r8WR2h3NaFxFKMlwlq0uzNdGhD1ouKBn9XWEGYHKiPLw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.2.tgz",
+      "integrity": "sha512-mbWFYEZ00LBRDk3WvcXViwpdpkJQcfrM3seuKzFxZnF6wIBLMwrcWcsj+OUC/1L+86m8aQY9imXMAaQsAoGxow==",
       "requires": {
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-codec": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.1.tgz",
-      "integrity": "sha512-/IiNB7gQM2y2ZC/GAWOWDa8+iXfhr1g9Xe5979cQEOdCWDISvrAiv18cn3OtIQUhbYOR3gm7QtCpkq1to2takQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.2.tgz",
+      "integrity": "sha512-PQZiKx7fMnNwx4zxcUCm82VjnqK6wV4MEHSmMy3taj5dKfXV782IjRGyaDT+8TsmNqVdZIkve5zLRAzh+7kOhA==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-serde-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.1.tgz",
-      "integrity": "sha512-9E1/6ZGF7nB/Td3G1kcatU7VjjP8eZ/p/Q+0KsZc1AUPyv4lR15pmWnWj3iGBEGYI9qZBJ/7a/wPEPayabmA3Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.2.tgz",
+      "integrity": "sha512-qaHlcFI+ILE+gZV2B/aZMVXc9LG4v1Owa20dHlP0dLOiJ9WByOjtD2qZmYA/HO4qkkDZHEL/0baWc63aqLCHKQ==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-serde-universal": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.1.tgz",
-      "integrity": "sha512-J8a+8HH8oDPIgq8Px/nPLfu9vpIjQ7XUPtP3orbs8KUh0GznNthSTy1xZP5RXjRqGQEkxPvsHf1po2+QOsgNFw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.2.tgz",
+      "integrity": "sha512-iVC7/NFNWfSXllAxFNUuC4QlREdZjMmAOdISb6fwny/4mUDt1EtYLCrXq7gN1mIzhRPwMpL9YvQ8jpgvfA0Jdw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-serde-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.1.tgz",
-      "integrity": "sha512-wklowUz0zXJuqC7FMpriz66J8OAko3z6INTg+iMJWYB1bWv4pc5V7q36PxlZ0RKRbj0u+EThlozWgzE7Stz2Sw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.2.tgz",
+      "integrity": "sha512-p7py8jDpIS1bRewskwgEgJx1OkFvockA2bJnXtOAPJib42DtyRpp8oV14s2ZpjMq57r9KMCQy2j02g554DNavg==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-serde-universal": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/eventstream-serde-universal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.1.tgz",
-      "integrity": "sha512-WPPylIgVZ6wOYVgpF0Rs1LlocYyj248MRtKEEehnDvC+0tV7wmGt7H/SchCh10W4y4YUxuzPlW+mUvVMGmLSVg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.2.tgz",
+      "integrity": "sha512-zf/hm5VIDsvl+XpI1rop4xwXLKiBUe5pxgjRFdHi7AC1p6Zc8uJfyCExLiMUP/QspoIrVV1xGwFFxRCeddDH3g==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/eventstream-codec": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.1.tgz",
-      "integrity": "sha512-/SoU/ClazgcdOxgE4zA7RX8euiELwpsrKCSvulVQvu9zpmqJRyEJn8ZTWYFV17/eHOBdHTs9kqodhNhsNT+cUw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.2.tgz",
+      "integrity": "sha512-Wo2m1RaiXNSLF4J3D62LpdSoj/YYb+6tn0H8is1tSrzr7eXAdiYVBc0wIa23N0wT4zmN0iG/yNY6gTCDQ6799A==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-base64": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-blob-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.1.tgz",
-      "integrity": "sha512-i/o2+sHb4jDRz5nf2ilTTbC0nVmm4LO//FbODCAB7pbzMdywxbZ6z+q56FmEa8R+aFbtApxQ1SJ3umEiNz6IPg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.0.2.tgz",
+      "integrity": "sha512-CmVGWbiyiEySGDRg3o2C3DLZYW+mH8fMoIEZrmwnBM8bQsepZGOME40tbpvv12BIhZIInJV8srMMHpQ6aKObLA==",
       "requires": {
         "@smithy/chunked-blob-reader": "^2.0.0",
         "@smithy/chunked-blob-reader-native": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.1.tgz",
-      "integrity": "sha512-oTKYimQdF4psX54ZonpcIE+MXjMUWFxLCNosjPkJPFQ9whRX0K/PFX/+JZGRQh3zO9RlEOEUIbhy9NO+Wha6hw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.2.tgz",
+      "integrity": "sha512-JKDzZ1YVR7JzOBaJoWy3ToJCE86OQE6D4kOBvvVsu93a3lcF9kv6KYTKBYEWAjwOn/CpK4NH7mKB01OQ8H+aiA==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/hash-stream-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.1.tgz",
-      "integrity": "sha512-AequnQdPRuXf4AuvvFlSjnkWI460xxhAd6y362gFtOE4jjJLLXblbMAXVFrkV8/pDMGNjpVegVSpRmHXZsbKhg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.0.2.tgz",
+      "integrity": "sha512-cDfGE81BbykXKZ50+eLU5Yat8WGiDFQpNa+5S3AfDIzz5h4D73DpxWwcwV4qYB7GoAw2chFqTCAGWgU/MgRS9g==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/invalid-dependency": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.1.tgz",
-      "integrity": "sha512-2q/Eb0AE662zwyMV+z+TL7deBwcHCgaZZGc0RItamBE8kak3MzCi/EZCNoFWoBfxgQ4jfR12wm8KKsSXhJzJtQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.2.tgz",
+      "integrity": "sha512-inQZQ5gCO3WRWuXpsc1YJ4KBjsvj2qsoU32yTIKznBWTCQe/D5Dp+sSaysqBqxe0VTZ+8nFEHdUMWUX2BxQThw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7745,45 +7237,45 @@
       }
     },
     "@smithy/md5-js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.1.tgz",
-      "integrity": "sha512-8WWOtwWMmIDgTkRv1o3opy3ABsRXs4/XunETK53ckxQRAiOML1PlnqLBK9Uwk9bvOD6cpmsC6dioIfmKGpJ25w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.2.tgz",
+      "integrity": "sha512-qm9845tzkYOm3HM/nFiZVMsA9nE7klO69T1qrrbrQKpUJpEFV87XDInbnRpYzBAFUH4DRodbZ9spEnjF7ffoww==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.1.tgz",
-      "integrity": "sha512-IZhRSk5GkVBcrKaqPXddBS2uKhaqwBgaSgbBb1OJyGsKe7SxRFbclWS0LqOR9fKUkDl+3lL8E2ffpo6EQg0igw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.2.tgz",
+      "integrity": "sha512-FmHlNfuvYgDZE3fIx0G3rD/wLXfAmBYE4mVc/w6d7RllA7TygPzq2pfHL1iCMzWkWTdoAVnt3h4aavAZnhaxEQ==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.1.tgz",
-      "integrity": "sha512-uz/KI1MBd9WHrrkVFZO4L4Wyv24raf0oR4EsOYEeG5jPJO5U+C7MZGLcMxX8gWERDn1sycBDqmGv8fjUMLxT6w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.2.tgz",
+      "integrity": "sha512-ropE7/c+g22QeluZ+By/B/WvVep0UFreX+IeRMGIO7EbOUPgqtJRXpbJFdG6JKB1uC+CdaJLn4MnZnVBpcyjuA==",
       "requires": {
-        "@smithy/middleware-serde": "^2.0.1",
-        "@smithy/types": "^2.0.2",
-        "@smithy/url-parser": "^2.0.1",
+        "@smithy/middleware-serde": "^2.0.2",
+        "@smithy/types": "^2.1.0",
+        "@smithy/url-parser": "^2.0.2",
         "@smithy/util-middleware": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/middleware-retry": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.1.tgz",
-      "integrity": "sha512-NKHF4i0gjSyjO6C0ZyjEpNqzGgIu7s8HOK6oT/1Jqws2Q1GynR1xV8XTUs1gKXeaNRzbzKQRewHHmfPwZjOtHA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.2.tgz",
+      "integrity": "sha512-wtBUXqtZVriiXppYaFkUrybAPhFVX7vebnW/yVPliLMWMcguOMS58qhOYPZe3t9Wki2+mASfyu+kO3An8lAg2A==",
       "requires": {
-        "@smithy/protocol-http": "^2.0.1",
+        "@smithy/protocol-http": "^2.0.2",
         "@smithy/service-error-classification": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-retry": "^2.0.0",
         "tslib": "^2.5.0",
@@ -7798,11 +7290,11 @@
       }
     },
     "@smithy/middleware-serde": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.1.tgz",
-      "integrity": "sha512-uKxPaC6ItH9ZXdpdqNtf8sda7GcU4SPMp0tomq/5lUg9oiMa/Q7+kD35MUrpKaX3IVXVrwEtkjCU9dogZ/RAUA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.2.tgz",
+      "integrity": "sha512-Kw9xLdlueIaivUWslKB67WZ/cCUg3QnzYVIA3t5KfgsseEEuU4UxXw8NSTvIt71gqQloY+Um8ugS+idgxrWWnw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7815,73 +7307,73 @@
       }
     },
     "@smithy/node-config-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.1.tgz",
-      "integrity": "sha512-Zoel4CPkKRTQ2XxmozZUfqBYqjPKL53/SvTDhJHj+VBSiJy6MXRav1iDCyFPS92t40Uh+Yi+Km5Ch3hQ+c/zSA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.2.tgz",
+      "integrity": "sha512-9wVJccASfuCctNWrzR0zrDkf0ox3HCHGEhFlWL2LBoghUYuK28pVRBbG69wvnkhlHnB8dDZHagxH+Nq9dm7eWw==",
       "requires": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/shared-ini-file-loader": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/shared-ini-file-loader": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/node-http-handler": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.1.tgz",
-      "integrity": "sha512-Zv3fxk3p9tsmPT2CKMsbuwbbxnq2gzLDIulxv+yI6aE+02WPYorObbbe9gh7SW3weadMODL1vTfOoJ9yFypDzg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.2.tgz",
+      "integrity": "sha512-lpZjmtmyZqSAtMPsbrLhb7XoAQ2kAHeuLY/csW6I2k+QyFvOk7cZeQsqEngWmZ9SJaeYiDCBINxAIM61i5WGLw==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/protocol-http": "^2.0.1",
-        "@smithy/querystring-builder": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/protocol-http": "^2.0.2",
+        "@smithy/querystring-builder": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "@smithy/abort-controller": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-          "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+          "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
           "requires": {
-            "@smithy/types": "^2.0.2",
+            "@smithy/types": "^2.1.0",
             "tslib": "^2.5.0"
           }
         }
       }
     },
     "@smithy/property-provider": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.1.tgz",
-      "integrity": "sha512-pmJRyY9SF6sutWIktIhe+bUdSQDxv/qZ4mYr3/u+u45riTPN7nmRxPo+e4sjWVoM0caKFjRSlj3tf5teRFy0Vg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.2.tgz",
+      "integrity": "sha512-DfaZ8cO+d/mgnMzIllcXcU4OYP+omiOl2LYdn/fTGpw/EAQSVzscYV2muV3sDDnuPYQ/r014hUqIxnF+pzh+SQ==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/protocol-http": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.1.tgz",
-      "integrity": "sha512-mrkMAp0wtaDEIkgRObWYxI1Kun1tm6Iu6rK+X4utb6Ah7Uc3Kk4VIWwK/rBHdYGReiLIrxFCB1rq4a2gyZnSgg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.2.tgz",
+      "integrity": "sha512-qWu8g1FUy+m36KpO1sREJSF7BaLmjw9AqOuwxLVVSdYz+nUQjc9tFAZ9LB6jJXKdsZFSjfkjHJBbhD78QdE7Rw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-builder": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.1.tgz",
-      "integrity": "sha512-bp+93WFzx1FojVEIeFPtG0A1pKsFdCUcZvVdZdRlmNooOUrz9Mm9bneRd8hDwAQ37pxiZkCOxopSXXRQN10mYw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.2.tgz",
+      "integrity": "sha512-H99LOMWEssfwqkOoTs4Y12UiZ7CTGQSX5Nrx5UkYgRbUEpC1GnnaprHiYrqclC58/xr4K76aNchdPyioxewMzA==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-uri-escape": "^2.0.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/querystring-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.1.tgz",
-      "integrity": "sha512-h+e7k1z+IvI2sSbUBG9Aq46JsgLl4UqIUl6aigAlRBj+P6ocNXpM6Yn1vMBw5ijtXeZbYpd1YvCxwDgdw3jhmg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.2.tgz",
+      "integrity": "sha512-L4VtKQ8O4/aWPQJbiFymbhAmxdfLnEaROh/Vs0OstJ7jtOZeBl2QJmuWY2V7hjt64W7V+tEn2sv6vVvnxkm/xQ==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7891,22 +7383,22 @@
       "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw=="
     },
     "@smithy/shared-ini-file-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.1.tgz",
-      "integrity": "sha512-a463YiZrPGvM+F336rIF8pLfQsHAdCRAn/BiI/EWzg5xLoxbC7GSxIgliDDXrOu0z8gT3nhVsif85eU6jyct3A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.2.tgz",
+      "integrity": "sha512-2VkNOM/82u4vatVdK5nfusgGIlvR48Fkq6me17Oc+V1iyxfR/1x0pG6LzW0br1qlGtzBYFZKmDyviBRcPVFTVw==",
       "requires": {
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/signature-v4": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.1.tgz",
-      "integrity": "sha512-jztv5Mirca42ilxmMDjzLdXcoAmRhZskGafGL49sRo5u7swEZcToEFrq6vtX5YMbSyTVrE9Teog5EFexY5Ff2Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.2.tgz",
+      "integrity": "sha512-YMooDEw/UmGxcXY4qWnSXkbPFsRloluSvyXVT678YPDN/K2AS1GzKfRsvSU7fbccOB4WF8MHZf2UqcRGEltE3Q==",
       "requires": {
-        "@smithy/eventstream-codec": "^2.0.1",
+        "@smithy/eventstream-codec": "^2.0.2",
         "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-hex-encoding": "^2.0.0",
         "@smithy/util-middleware": "^2.0.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -7915,31 +7407,31 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.1.tgz",
-      "integrity": "sha512-LHC5m6tYpEu1iNbONfvMbwtErboyTZJfEIPoD78Ei5MVr36vZQCaCla5mvo36+q/a2NAk2//fA5Rx3I1Kf7+lQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.2.tgz",
+      "integrity": "sha512-mDfokI8WwLU5C0gcQ4ww/zJI/WLGSh2+vdIA42JRnjfYUjJNH/rKfX9YOnn2eBOxl3loATERVUqkHmKe+P8s2Q==",
       "requires": {
         "@smithy/middleware-stack": "^2.0.0",
-        "@smithy/types": "^2.0.2",
-        "@smithy/util-stream": "^2.0.1",
+        "@smithy/types": "^2.1.0",
+        "@smithy/util-stream": "^2.0.2",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.0.2.tgz",
-      "integrity": "sha512-wcymEjIXQ9+NEfE5Yt5TInAqe1o4n+Nh+rh00AwoazppmUt8tdo6URhc5gkDcOYrcvlDVAZE7uG69nDpEGUKxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-KLsCsqxX0j2l99iP8s0f7LBlcsp7a7ceXGn0LPYPyVOsqmIKvSaPQajq0YevlL4T9Bm+DtcyXfBTbtBcLX1I7A==",
       "requires": {
         "tslib": "^2.5.0"
       }
     },
     "@smithy/url-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.1.tgz",
-      "integrity": "sha512-NpHVOAwddo+OyyIoujDL9zGL96piHWrTNXqltWmBvlUoWgt1HPyBuKs6oHjioyFnNZXUqveTOkEEq0U5w6Uv8A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.2.tgz",
+      "integrity": "sha512-X1mHCzrSVDlhVy7d3S7Vq+dTfYzwh4n7xGHhyJumu77nJqIss0lazVug85Pwo0DKIoO314wAOvMnBxNYDa+7wA==",
       "requires": {
-        "@smithy/querystring-parser": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/querystring-parser": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -7986,26 +7478,26 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.1.tgz",
-      "integrity": "sha512-w72Qwsb+IaEYEFtYICn0Do42eFju78hTaBzzJfT107lFOPdbjWjKnFutV+6GL/nZd5HWXY7ccAKka++C3NrjHw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.2.tgz",
+      "integrity": "sha512-c2tMMjb624XLuzmlRoZpnFOkejVxcgw3WQKdmgdGZYZapcLzXyC0H9JhnXMjQCt30GqLTlsILRNVBYwFRbw/4Q==",
       "requires": {
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "bowser": "^2.11.0",
         "tslib": "^2.5.0"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.1.tgz",
-      "integrity": "sha512-dNF45caelEBambo0SgkzQ0v76m4YM+aFKZNTtSafy7P5dVF8TbjZuR2UX1A5gJABD9XK6lzN+v/9Yfzj/EDgGg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.2.tgz",
+      "integrity": "sha512-gt7m5LLqUtEKldJLyc14DE4kb85vxwomvt9AfEMEvWM4VwfWS1kGJqiStZFb5KNqnQPXw8vvpgLTi8NrWAOXqg==",
       "requires": {
-        "@smithy/config-resolver": "^2.0.1",
-        "@smithy/credential-provider-imds": "^2.0.1",
-        "@smithy/node-config-provider": "^2.0.1",
-        "@smithy/property-provider": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/config-resolver": "^2.0.2",
+        "@smithy/credential-provider-imds": "^2.0.2",
+        "@smithy/node-config-provider": "^2.0.2",
+        "@smithy/property-provider": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       }
     },
@@ -8035,13 +7527,13 @@
       }
     },
     "@smithy/util-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.1.tgz",
-      "integrity": "sha512-2a0IOtwIKC46EEo7E7cxDN8u2jwOiYYJqcFKA6rd5rdXqKakHT2Gc+AqHWngr0IEHUfW92zX12wRQKwyoqZf2Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.2.tgz",
+      "integrity": "sha512-Mg9IJcKIu4YKlbzvpp1KLvh4JZLdcPgpxk+LICuDwzZCfxe47R9enVK8dNEiuyiIGK2ExbfvzCVT8IBru62vZw==",
       "requires": {
-        "@smithy/fetch-http-handler": "^2.0.1",
-        "@smithy/node-http-handler": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/fetch-http-handler": "^2.0.2",
+        "@smithy/node-http-handler": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "@smithy/util-base64": "^2.0.0",
         "@smithy/util-buffer-from": "^2.0.0",
         "@smithy/util-hex-encoding": "^2.0.0",
@@ -8067,21 +7559,21 @@
       }
     },
     "@smithy/util-waiter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.1.tgz",
-      "integrity": "sha512-bSyGFicPRYuGFFWAr72UvYI7tE7KmEeFJJ5iaLuTTdo8RGaNBZ2kE25coGtzrejYh9AhwSfckBvbxgEDxIxhlA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.2.tgz",
+      "integrity": "sha512-7XCEVXDLguf3Og0NIF/KYEAHtrzNXmCdtEwMfOXr4iBKOUWYzNj91YB9O7tLrct8VGvysGA0x2xYzbxMbvF0QQ==",
       "requires": {
-        "@smithy/abort-controller": "^2.0.1",
-        "@smithy/types": "^2.0.2",
+        "@smithy/abort-controller": "^2.0.2",
+        "@smithy/types": "^2.1.0",
         "tslib": "^2.5.0"
       },
       "dependencies": {
         "@smithy/abort-controller": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.1.tgz",
-          "integrity": "sha512-0s7XjIbsTwZyUW9OwXQ8J6x1UiA1TNCh60Vaw56nHahL7kUZsLhmTlWiaxfLkFtO2Utkj8YewcpHTYpxaTzO+w==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
+          "integrity": "sha512-ln5Cob0mksym62sLr7NiPOSqJ0jKao4qjfcNLDdgINM1lQI12hXrZBlKdPHbXJqpKhKiECDgonMoqCM8bigq4g==",
           "requires": {
-            "@smithy/types": "^2.0.2",
+            "@smithy/types": "^2.1.0",
             "tslib": "^2.5.0"
           }
         }
@@ -9724,9 +9216,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "require-from-string": {
       "version": "2.0.2",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-app",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "license": "BSD-3-Clause-Clear",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "test:ui": "vite build && vitest --ui"
   },
   "dependencies": {
-    "@opentdf/client": "file:../lib/opentdf-client-1.2.2.tgz",
+    "@opentdf/client": "file:../lib/opentdf-client-1.3.0.tgz",
     "clsx": "^2.0.0",
     "native-file-system-adapter": "^3.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
Why? TDF files should be considered user generated content, and any data from them should be suspect. In this case, we don't want to send random upsert / rewrap requests to unknown/unsafe URIs.

This throws an UnsafeUrlError in this case, which has a `.url` parameter which will allow applications to prompt the user to see if the URL is 'safe'. 