### PR TITLE
✨Type fixes

### DIFF
--- a/lib/tdf3/index.ts
+++ b/lib/tdf3/index.ts
@@ -29,12 +29,14 @@ import {
   clientType,
 } from '../src/index.js';
 import { Algorithms, type AlgorithmName, type AlgorithmUrn } from './src/ciphers/algorithms.js';
+import { type Chunker } from './src/utils/chunkers.js';
 
 window.TDF = TDF;
 
 export type {
   AlgorithmName,
   AlgorithmUrn,
+  Chunker,
   CryptoService,
   DecryptResult,
   EncryptResult,

--- a/lib/tdf3/src/crypto/declarations.ts
+++ b/lib/tdf3/src/crypto/declarations.ts
@@ -32,7 +32,8 @@ export type CryptoService<PairT = CryptoKeyPair> = {
   /** Default algorithm identifier. */
   method: AlgorithmUrn;
 
-  cryptoToPemPair: (keys: PairT) => Promise<PemKeyPair>;
+  /** Convert from PairT to PemKeyPair */
+  cryptoToPemPair: (keys: unknown) => Promise<PemKeyPair>;
 
   /**
    * Try to decrypt content with the default or handed algorithm. Throws on

--- a/lib/tdf3/src/crypto/index.ts
+++ b/lib/tdf3/src/crypto/index.ts
@@ -83,7 +83,12 @@ export async function generateKeyPair(size?: number): Promise<CryptoKeyPair> {
   return crypto.subtle.generateKey(algoDomString, true, METHODS);
 }
 
-export async function cryptoToPemPair(keys: CryptoKeyPair): Promise<PemKeyPair> {
+export async function cryptoToPemPair(keysMaybe: unknown): Promise<PemKeyPair> {
+  const keys = keysMaybe as CryptoKeyPair;
+  if (!keys.publicKey || !keys.publicKey) {
+    throw new Error('invalid');
+  }
+
   const [exPublic, exPrivate] = await Promise.all([
     crypto.subtle.exportKey('spki', keys.publicKey),
     crypto.subtle.exportKey('pkcs8', keys.privateKey),

--- a/lib/tdf3/src/crypto/index.ts
+++ b/lib/tdf3/src/crypto/index.ts
@@ -85,7 +85,7 @@ export async function generateKeyPair(size?: number): Promise<CryptoKeyPair> {
 
 export async function cryptoToPemPair(keysMaybe: unknown): Promise<PemKeyPair> {
   const keys = keysMaybe as CryptoKeyPair;
-  if (!keys.publicKey || !keys.publicKey) {
+  if (!keys.privateKey || !keys.publicKey) {
     throw new Error('invalid');
   }
 

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -22,13 +22,13 @@ import {
 import { base64 } from '../../src/encodings/index.js';
 import * as defaultCryptoService from './crypto/index.js';
 import {
-  base64ToBuffer,
-  fromUrl,
-  keyMerge,
+  type Chunker,
   ZipReader,
   ZipWriter,
-  Chunker,
+  base64ToBuffer,
+  fromUrl,
   isAppIdProviderCheck,
+  keyMerge,
 } from './utils/index.js';
 import { Binary } from './binary.js';
 import {

--- a/lib/tests/mocha/unit/crypto-di.spec.ts
+++ b/lib/tests/mocha/unit/crypto-di.spec.ts
@@ -14,7 +14,7 @@ describe('CryptoService DI', () => {
     const cryptoService: CryptoService = {
       name: 'mock',
       method: 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-      cryptoToPemPair: function (keys: CryptoKeyPair): Promise<PemKeyPair> {
+      cryptoToPemPair: function (keys: unknown): Promise<PemKeyPair> {
         throw new Error('Function not implemented.');
       },
       decrypt: function (

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -2004,7 +2004,7 @@
     "node_modules/@opentdf/client": {
       "version": "1.2.0",
       "resolved": "file:../lib/opentdf-client-1.2.0.tgz",
-      "integrity": "sha512-v0o9W3vqBShC2vAiX8fUBrmdgz6iSEqZQXRJhu6T5STYNWmvVEcSTn1osuWR31ORCYOOpIb7SJgwX2kEFz6c5A==",
+      "integrity": "sha512-oDgus11S/vkXuDj1T5dDxD6j4kIf6ofdS+sBkA+VGsU4GMibQfZyt7eBECriCswMWJvpYxM6/otJL9wu8XasxA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@aws-sdk/abort-controller": "^3.357.0",
@@ -7376,7 +7376,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-1.2.0.tgz",
-      "integrity": "sha512-v0o9W3vqBShC2vAiX8fUBrmdgz6iSEqZQXRJhu6T5STYNWmvVEcSTn1osuWR31ORCYOOpIb7SJgwX2kEFz6c5A==",
+      "integrity": "sha512-oDgus11S/vkXuDj1T5dDxD6j4kIf6ofdS+sBkA+VGsU4GMibQfZyt7eBECriCswMWJvpYxM6/otJL9wu8XasxA==",
       "requires": {
         "@aws-sdk/abort-controller": "^3.357.0",
         "@aws-sdk/client-s3": "^3.367.0",


### PR DESCRIPTION
- updates export to include Chunker, useful in directly calling decrypt with no builder
- lets `cryptoToPemPair` take an unknown argument. Sometimes generics [just don't work](https://stackoverflow.com/a/105812)