### PR TITLE
Remove segmentHash from integrityInformation

### DIFF
--- a/lib/tdf3/src/models/encryption-information.ts
+++ b/lib/tdf3/src/models/encryption-information.ts
@@ -32,7 +32,6 @@ export type EncryptionInformation = {
       alg: string;
       sig: string;
     };
-    readonly segmentHash: string;
     segmentHashAlg: string;
     segments: Segment[];
     segmentSizeDefault?: number;
@@ -153,7 +152,6 @@ export class SplitKey {
           sig: '',
         },
         segmentHashAlg: '',
-        segmentHash: '',
         segments: [],
       },
       policy: policyForManifest,


### PR DESCRIPTION
To make the client-web more conformant to the specification, remove `segmentHash`

See https://github.com/opentdf/spec/blob/main/schema/tdf/manifest-json.md#encryptioninformationintegrityinformation

```
"integrityInformation": {
  "rootSignature": {
    "alg": "HS256",
    "sig": "M2E2MTI5YmMxMWU0ODIzZDA4YTdkNTY2MzdlNDM4OGRlZDE2MTFhZjU1YTY1YzBhYWNlMWVjYjlmODUzNmNiZQ=="
  },
  "segmentHashAlg": "GMAC",
  "segments": [<Segment Object>],
  "segmentSizeDefault": 1000000,
  "encryptedSegmentSizeDefault": 1000028
}
```