### PR TITLE
🧹 Remove a side effect, restores missing source code

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -10,6 +10,8 @@
     "dist/*/src/**",
     "dist/*/tdf3/**",
     "dist/*/*.json",
+    "src/**",
+    "tdf3/**",
     "README.md"
   ],
   "repository": {


### PR DESCRIPTION
- Include source code in the bundle. This makes tracing code easier in debuggers.
- Lazily configures axios to allow axios to be tree-shook and avoid unnecessary initialization
