### PR TITLE
✨ KAS Key Identifier support

### DIFF
--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -15,9 +15,12 @@ import { UnsafeUrlError } from './errors.js';
  * @param url remote service to validate
  * @returns the url is local or `https`
  */
-export function validateSecureUrl(url: string): boolean {
+export function validateSecureUrl(url: string, strict?: boolean): boolean {
   const httpsRegex = /^https:/;
   if (/^http:\/\/(localhost|127\.0\.0\.1)(:[0-9]{1,5})?($|\/)/.test(url)) {
+    if (strict) {
+      throw new UnsafeUrlError('Dev URL', url);
+    }
     console.warn(`Development URL detected: [${url}]`);
   } else if (
     /^http:\/\/([a-zA-Z.-]*[.])?svc\.cluster\.local($|\/)/.test(url) ||
@@ -25,6 +28,9 @@ export function validateSecureUrl(url: string): boolean {
   ) {
     console.info(`Internal URL detected: [${url}]`);
   } else if (!httpsRegex.test(url)) {
+    if (strict) {
+      throw new UnsafeUrlError('KAS must be secure', url);
+    }
     console.error(`Insecure KAS URL loaded. Are you running in a secure environment? [${url}]`);
     return false;
   }

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -9,7 +9,7 @@ import {
   type Chunker,
 } from '../utils/index.js';
 import { base64 } from '../../../src/encodings/index.js';
-import { TDF } from '../tdf.js';
+import { fetchKasPublicKey, KasPublicKeyInfo, TDF } from '../tdf.js';
 import { OIDCRefreshTokenProvider } from '../../../src/auth/oidc-refreshtoken-provider.js';
 import { OIDCExternalJwtProvider } from '../../../src/auth/oidc-externaljwt-provider.js';
 import { CryptoService, PemKeyPair } from '../crypto/declarations.js';
@@ -157,24 +157,6 @@ export async function createSessionKeys({
   return { keypair: k2, signingKeys };
 }
 
-/**
- * If we have KAS url but not public key we can fetch it from KAS, fetching
- * the value from `${kas}/kas_public_key`.
- */
-export async function fetchKasPubKey(kas: string): Promise<string> {
-  if (!kas) {
-    throw new TdfError('KAS definition not found');
-  }
-  try {
-    return await TDF.getPublicKeyFromKeyAccessServer(kas);
-  } catch (cause) {
-    throw new TdfError(
-      `Retrieving KAS public key [${kas}] failed [${cause.name}] [${cause.message}]`,
-      cause
-    );
-  }
-}
-
 export type SessionKeys = {
   keypair: PemKeyPair;
   signingKeys?: CryptoKeyPair;
@@ -194,7 +176,7 @@ export class Client {
    */
   readonly allowedKases: string[];
 
-  readonly kasPublicKey: Promise<string>;
+  readonly kasPublicKey: Promise<KasPublicKeyInfo>;
 
   readonly easEndpoint?: string;
 
@@ -246,10 +228,16 @@ export class Client {
 
     if (clientConfig.allowedKases) {
       this.allowedKases = [...clientConfig.allowedKases];
+      if (!validateSecureUrl(this.kasEndpoint) && !this.allowedKases.includes(this.kasEndpoint)) {
+        throw new TdfError(`Invalid KAS endpoint [${this.kasEndpoint}]`);
+      }
+      this.allowedKases.forEach((k) => validateSecureUrl(k, true));
     } else {
+      if (!validateSecureUrl(this.kasEndpoint)) {
+        throw new TdfError(`Invalid KAS endpoint [${this.kasEndpoint}]; to force, please list it among allowedKases`);
+      }
       this.allowedKases = [this.kasEndpoint];
     }
-    this.allowedKases.forEach(validateSecureUrl);
 
     this.authProvider = config.authProvider;
     this.clientConfig = clientConfig;
@@ -298,9 +286,13 @@ export class Client {
       });
     }
     if (clientConfig.kasPublicKey) {
-      this.kasPublicKey = Promise.resolve(clientConfig.kasPublicKey);
+      this.kasPublicKey = Promise.resolve({
+        url: this.kasEndpoint,
+        algorithm: 'rsa:2048',
+        pem: clientConfig.kasPublicKey
+      });
     } else {
-      this.kasPublicKey = fetchKasPubKey(this.kasEndpoint);
+      this.kasPublicKey = fetchKasPublicKey(this.kasEndpoint);
     }
   }
 
@@ -395,8 +387,9 @@ export class Client {
     }
     await tdf.addKeyAccess({
       type: offline ? 'wrapped' : 'remote',
-      url: this.kasEndpoint,
-      publicKey: kasPublicKey,
+      url: kasPublicKey.url,
+      kid: kasPublicKey.kid,
+      publicKey: kasPublicKey.pem,
       metadata,
     });
 

--- a/lib/tdf3/src/models/attribute-set.ts
+++ b/lib/tdf3/src/models/attribute-set.ts
@@ -6,6 +6,7 @@ const verbose = false;
 export type AttributeObject = {
   attribute: string;
   kasUrl: string;
+  kid?: string;
   pubKey: string;
   displayName?: string;
   isDefault?: boolean;
@@ -21,6 +22,7 @@ const ATTRIBUTE_OBJECT_SCHEMA: JSONSchemaType<AttributeObject> = {
     isDefault: { type: 'boolean', nullable: true },
     pubKey: { type: 'string' },
     kasUrl: { type: 'string' },
+    kid: { type: 'string', nullable: true },
     jwt: { type: 'string', nullable: true },
   },
   required: ['attribute', 'pubKey', 'kasUrl'],

--- a/lib/tdf3/src/models/key-access.ts
+++ b/lib/tdf3/src/models/key-access.ts
@@ -15,8 +15,9 @@ export class Wrapped {
 
   constructor(
     public readonly url: string,
+    public readonly kid: string | undefined,
     public readonly publicKey: string,
-    public readonly metadata: unknown
+    public readonly metadata: unknown,
   ) {}
 
   async write(
@@ -44,6 +45,9 @@ export class Wrapped {
       encryptedMetadata: base64.encode(encryptedMetadataStr),
       policyBinding: base64.encode(policyBinding),
     };
+    if (this.kid) {
+      this.keyAccessObject.kid = this.kid;
+    }
 
     return this.keyAccessObject;
   }
@@ -57,6 +61,7 @@ export class Remote {
 
   constructor(
     public readonly url: string,
+    public readonly kid: string | undefined,
     public readonly publicKey: string,
     public readonly metadata: unknown
   ) {}
@@ -88,6 +93,9 @@ export class Remote {
       encryptedMetadata: base64.encode(encryptedMetadataStr),
       policyBinding: base64.encode(policyBinding),
     };
+    if (this.kid) {
+      this.keyAccessObject.kid = this.kid;
+    }
     return this.keyAccessObject;
   }
 }
@@ -97,6 +105,7 @@ export type KeyAccess = Remote | Wrapped;
 export type KeyAccessObject = {
   type: KeyAccessType;
   url: string;
+  kid?: string;
   protocol: 'kas';
   wrappedKey?: string;
   policyBinding?: string;

--- a/lib/tests/mocha/client.spec.ts
+++ b/lib/tests/mocha/client.spec.ts
@@ -5,7 +5,7 @@ import { DecoratedReadableStream } from '../../tdf3/src/client/DecoratedReadable
 describe('client wrapper tests', function () {
   it('client params safe from updating', function () {
     const config = {
-      kasEndpoint: 'kasUrl',
+      kasEndpoint: 'https://kasUrl',
       clientId: 'id',
     };
     const client = new TDF.Client(config);
@@ -118,7 +118,7 @@ describe('client wrapper tests', function () {
   it('encrypt error', async function () {
     const encryptParams = new TDF.EncryptParamsBuilder().withStringSource('hello world').build();
     const config = {
-      kasEndpoint: 'kasUrl',
+      kasEndpoint: 'https://kasUrl',
       clientId: 'id',
     };
     const client = new TDF.Client(config);
@@ -133,7 +133,7 @@ describe('client wrapper tests', function () {
   it('decrypt error', async function () {
     const decryptParams = new TDF.DecryptParamsBuilder().withStringSource('not a tdf').build();
     const config = {
-      kasEndpoint: 'kasUrl',
+      kasEndpoint: 'https://kasUrl',
       clientId: 'id',
     };
     const client = new TDF.Client(config);

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 
-import { TDF } from '../../../tdf3/src/index.js';
+import { TDF, fetchKasPublicKey } from '../../../tdf3/src/tdf.js';
 import * as cryptoService from '../../../tdf3/src/crypto/index.js';
 import { AesGcmCipher } from '../../../tdf3/src/ciphers/aes-gcm-cipher.js';
+import { TdfError, UnsafeUrlError } from '../../../src/errors.js';
 const sampleCert = `
 -----BEGIN CERTIFICATE-----
 MIIFnjCCA4YCCQCnKw0cfbMLJTANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC
@@ -107,5 +108,35 @@ describe('TDF', () => {
   it('should ensure that policy id is uuid format', async () => {
     const uuid = await TDF.create({ cryptoService }).generatePolicyUuid();
     expect(uuid).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+});
+
+
+describe('fetchKasPublicKey', async () => {
+  it('missing kas names throw', async () => {
+    try {
+      await fetchKasPublicKey('');
+      expect.fail('did not throw');
+    } catch (e) {
+      expect(e).to.be.an.instanceof(TdfError);
+    }
+  });
+
+
+  it('unsafe kas names throw', async () => {
+    let failed = false;
+    try {
+      await fetchKasPublicKey('http://example.com');
+      failed = true;
+    } catch (e) {
+      expect(e).to.be.an.instanceof(UnsafeUrlError);
+    }
+    expect(failed).to.be.false;
+  });
+
+  it('localhost kas is valid', async () => {
+    const pk2 = await fetchKasPublicKey('http://localhost:3000', false);
+    expect(pk2.pem).to.include('BEGIN CERTIFICATE');
+    expect(pk2.kid).to.equal('kid-a');
   });
 });

--- a/lib/tests/server.cjs
+++ b/lib/tests/server.cjs
@@ -1,4 +1,41 @@
-const http = require('http');
+const http = require('node:http');
+
+const kid = 'kid-a';
+const pem = `
+-----BEGIN CERTIFICATE-----
+MIIFnjCCA4YCCQCnKw0cfbMLJTANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMC
+VUExCzAJBgNVBAgMAk9EMQ4wDAYDVQQHDAVPREVTQTEPMA0GA1UECgwGVklSVFJV
+MREwDwYDVQQLDAhQTEFURk9STTEZMBcGA1UEAwwQbG9jYWwudmlydHJ1LmNvbTEl
+MCMGCSqGSIb3DQEJARYWc2l2YW5vdi5jdHJAdmlydHJ1LmNvbTAeFw0yMzA3MDYx
+MTUxMzFaFw0yNDA3MDUxMTUxMzFaMIGQMQswCQYDVQQGEwJVQTELMAkGA1UECAwC
+T0QxDjAMBgNVBAcMBU9ERVNBMQ8wDQYDVQQKDAZWSVJUUlUxETAPBgNVBAsMCFBM
+QVRGT1JNMRkwFwYDVQQDDBBsb2NhbC52aXJ0cnUuY29tMSUwIwYJKoZIhvcNAQkB
+FhZzaXZhbm92LmN0ckB2aXJ0cnUuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+MIICCgKCAgEAn+CvhpQZ6lPZG8j07l8JWWQnmPATKB2GDbcyC/Yg1rJAcFLZmBvH
+VR3SamYQrSKxFRsoBGVruIFQBpoYMSolRWVVRnRBmpB5O8vCdP8J78mRaXGoJAez
+xexuZBEoUIJJAn0Uoxg462201RgzLrZq+b+gOHZzcOfMlh/HPWhTeLdW2i0oMddL
+yeykUa8ARHeCbA1Ux/IZju9n+lY3Pv7pI7z0mYuU14p33lvQbTZ1psY4frwFeyqC
+rqHR1NqKjX+CnitFDrVKV48ZNlBQ6y348NpCaNH0wmy4FRAuGS6dJb9KFK6C+KIj
+EQlWaucPTgvf6/dgZ6IZdLPvHUQNwC9yidRpnyLTUZlxwCXVO3P1sP7ifq75RwFk
+OhvGqnoWNxUwd+23YUOFhE5b7WSO8NwRiMPBeEhNiWaiCmu1v88h52mgRr74MjCQ
+mftuJlPwhsqWMpdYuv42851Y95x5s7BFWtntBNcU/+TTSKcygPNGkuR/tNw79JrM
+bMl/Wj+cJoCW/3+1KzmPX13Nf2Cq2KZ8Kx6JCy+zFj/Hu8O/iqZ1vxA7gUyESPrd
+NFB988QD7H8AQLCeDh6mOTdK08ZG74FlRBSk788A4oyslx8DslOkWbqHLdA7frv6
+rEtl3mJ9UchFVpJOXw5nT3plE0ZRx4NWRLAG2+8GIUsL6eylpFUfVH8CAwEAATAN
+BgkqhkiG9w0BAQsFAAOCAgEAlS3ph3ZcPf90uo0Y0l6Pca5I7ztuq6wu6reKAqnz
+kh6N1rpLSe6EdRIOOCkMWMYTlZYFnSG/USGRfiCV0TOoo2C+jFvARRn6oir1v3B4
+XBQORRNrOP8xV6kXAmNxs9Zl8CpAxfejV0vBHzN709q2HDfwmMmmp/yhlsAa1/iL
+ARYV3TIJBmAOpec2CemuSVwGvYF7Ojl4sTYl0qMzrmm85wMBHJWR9EJbbFZBDDi4
+GKVx26SfxaeauZXRgbO7Tav0q7mbJXI6u95aWO6iwkABRfnEQbimfVCjRI4TKlNs
+WX5PS3QXXJg/9ocEglNGDwTouDwD/yMevR2tJ4clb9SJkJjJ3I0t7aUoFHXBl0B2
+merKiN1ZE4OlbG/BsJypwAqV7Xk6tK3LM8fCMxhP1K0XX5Ifi1+hbN4Wr7a/zpEq
+RWFMXtPKqTne0Ut6M7Xv5BBjY3uBmp0AX9hXt00olAiZsrOfj4gjAVULxdsbaEpr
+nTqI65s26fls4y9bCZSfY//YNMAAtSRfmGbCZfrnzyvMtZfSMHqxhzMX7jXonV9c
+TuHue7faEGaGlWGQVdNeudZaQ/eimDWeWnbhoUz6hSX7NICUFE64W6+GVFsAte3s
+jtfbjUcLqvZzZt+u7YDapWbEbdgYjn/lUt0sTNyY65IagXJel9iacjCIVdzoKPzn
+HJg=
+-----END CERTIFICATE-----
+`.trim();
 
 function range(start, end) {
   const result = [];
@@ -11,7 +48,8 @@ function range(start, end) {
 const server = http.createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Range');
-  if (req.url === '/file' && req.method === 'GET') {
+  const url = new URL(req.url, `http://${req?.headers?.host}`);
+  if (url.pathname === '/file' && req.method === 'GET') {
     const start = 0;
     const end = 255;
     const fullRange = range(start, end);
@@ -47,12 +85,29 @@ const server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/octet-stream');
       res.end(Buffer.from(fullRange.buffer));
     }
-  } else if (req.url === '/stop' && req.method === 'GET') {
+  } else if (url.pathname === '/stop' && req.method === 'GET') {
     server.close(() => {
       console.log('Server gracefully terminated.');
     });
     res.statusCode = 200;
     res.end('Server stopped');
+  } else if (url.pathname === '/kas_public_key' && req.method === 'GET') {
+    const algorithm = url.searchParams.get('algorithm') || 'rsa:2048';
+    if (!['ec:secp256r1', 'rsa:2048'].includes(algorithm)) {
+      res.writeHead(400);
+      res.end();
+      return;
+    }
+    const fmt = url.searchParams.get('fmt') || 'pkcs8';
+    if (!['jwks', 'pkcs8'].includes(fmt)) {
+      res.writeHead(400);
+      res.end();
+      return;
+    }
+    const v2 = '2' == url.searchParams.get('v');
+    res.setHeader('Content-Type', 'application/json');
+    res.statusCode = 200;
+    res.end(JSON.stringify(v2 ? { kid, pem } : pem));
   } else if (req.method === 'OPTIONS') {
     res.statusCode = 200;
     res.end();

--- a/lib/tests/web/utils.test.ts
+++ b/lib/tests/web/utils.test.ts
@@ -9,6 +9,7 @@ import {
   safeUrlCheck,
   validateSecureUrl,
 } from '../../src/utils.js';
+import { UnsafeUrlError } from '../../src/errors.js';
 
 describe('rstrip', () => {
   describe('default', () => {
@@ -77,6 +78,11 @@ describe('validateSecureUrl', () => {
     expect(validateSecureUrl('http://svc.cluster.local')).to.be.true;
     expect(validateSecureUrl('http://amz.svc.cluster.local')).to.be.true;
     expect(validateSecureUrl('http://somesvc.cluster.local')).to.be.false;
+  });
+  it('strict mode', () => {
+    expect(() => validateSecureUrl('http://example.com', true)).to.throw(UnsafeUrlError);
+    expect(() => validateSecureUrl('', true)).to.throw(UnsafeUrlError);
+    expect(validateSecureUrl('https://example.com', true)).to.be.true;
   });
   it('mangled urls', () => {
     expect(validateSecureUrl('///hey.you')).to.be.false;

--- a/remote-store/package-lock.json
+++ b/remote-store/package-lock.json
@@ -1649,7 +1649,7 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-mSla6eFCUwFiYw/1oIEM+bmOf3+jWxDH9ihbFLMua1/UWzjHKP6toRyzkjsEKRtPei2ROtx9x1APKKN1pFZ5/A==",
+      "integrity": "sha512-UXWmg7xvx5X/QSp5YNKbskD1riV7vXcT/kaJWDgRUZKjRZC6ujrNEWjmZCPyjnoFcZe6JdQoZeC1sUxGg9oeDA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "ajv": "^8.12.0",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -644,7 +644,7 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-mSla6eFCUwFiYw/1oIEM+bmOf3+jWxDH9ihbFLMua1/UWzjHKP6toRyzkjsEKRtPei2ROtx9x1APKKN1pFZ5/A==",
+      "integrity": "sha512-UXWmg7xvx5X/QSp5YNKbskD1riV7vXcT/kaJWDgRUZKjRZC6ujrNEWjmZCPyjnoFcZe6JdQoZeC1sUxGg9oeDA==",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -4384,7 +4384,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-mSla6eFCUwFiYw/1oIEM+bmOf3+jWxDH9ihbFLMua1/UWzjHKP6toRyzkjsEKRtPei2ROtx9x1APKKN1pFZ5/A==",
+      "integrity": "sha512-UXWmg7xvx5X/QSp5YNKbskD1riV7vXcT/kaJWDgRUZKjRZC6ujrNEWjmZCPyjnoFcZe6JdQoZeC1sUxGg9oeDA==",
       "requires": {
         "ajv": "^8.12.0",
         "axios": "^1.4.0",


### PR DESCRIPTION
- Sends `v=2` when requesting kas_public_key for tdf3 content
- When connecting to a KAS that implements the new draft v2 return format, this will result in a response with the kid field present
- This is then baked into the key access object for future reference