### PR TITLE
chore: Removes ajv validation of attribute set

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
-        "ajv": "^8.12.0",
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
         "base64-js": "^1.5.1",
@@ -2787,21 +2786,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -4911,6 +4895,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -6695,11 +6680,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8790,6 +8770,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9072,14 +9053,6 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10541,6 +10514,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -13209,17 +13183,6 @@
         "indent-string": "^4.0.0"
       }
     },
-    "ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -14725,7 +14688,8 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "fast-fifo": {
       "version": "1.3.0",
@@ -15970,11 +15934,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17563,7 +17522,8 @@
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
     },
     "puppeteer-core": {
       "version": "20.9.0",
@@ -17754,11 +17714,6 @@
     "require-directory": {
       "version": "2.1.1",
       "dev": true
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -18792,6 +18747,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/lib/package.json
+++ b/lib/package.json
@@ -59,7 +59,6 @@
     "watch": "(trap 'kill 0' SIGINT; npm run build && (npm run build:watch & npm run test -- --watch))"
   },
   "dependencies": {
-    "ajv": "^8.12.0",
     "axios": "^1.6.1",
     "axios-retry": "^3.9.0",
     "base64-js": "^1.5.1",

--- a/lib/tdf3/src/models/attribute-set.ts
+++ b/lib/tdf3/src/models/attribute-set.ts
@@ -1,4 +1,3 @@
-import Ajv, { JSONSchemaType } from 'ajv';
 import { decodeJwt } from 'jose';
 
 export type AttributeObject = {
@@ -10,32 +9,6 @@ export type AttributeObject = {
   isDefault?: boolean;
   jwt?: string;
 };
-
-const ATTRIBUTE_OBJECT_SCHEMA: JSONSchemaType<AttributeObject> = {
-  $id: '/AttributeObject',
-  type: 'object',
-  properties: {
-    attribute: { type: 'string' },
-    displayName: { type: 'string', nullable: true },
-    isDefault: { type: 'boolean', nullable: true },
-    pubKey: { type: 'string' },
-    kasUrl: { type: 'string' },
-    kid: { type: 'string', nullable: true },
-    jwt: { type: 'string', nullable: true },
-  },
-  required: ['attribute', 'pubKey', 'kasUrl'],
-  additionalProperties: false,
-};
-
-const validator = (() => {
-  try {
-    //@ts-expect-error: Ajv not a constructor
-    return new Ajv();
-  } catch (e) {
-    console.log(e);
-  }
-  return new Ajv.default();
-})();
 
 export class AttributeSet {
   attributes: AttributeObject[];
@@ -97,15 +70,6 @@ export class AttributeSet {
    * @return the attribute object if successful, or null
    */
   addAttribute(attrObj: AttributeObject): AttributeObject | null {
-    // Check shape of object.  Reject semi-silently if malformed.
-    const validate = validator.compile(ATTRIBUTE_OBJECT_SCHEMA);
-    const result = validate(attrObj);
-    if (!result) {
-      // TODO: Determine if an error should be thrown
-      // console.log("WARNING - AttributeSet.addAttribute: AttributeObject is malformed. AddAttribute failed:");
-      if (this.verbose) console.log(attrObj);
-      return null;
-    }
     // Check for duplicate entries to assure idempotency.
     if (this.has(attrObj.attribute)) {
       // This may be a common occurance, so only un-comment this log message

--- a/lib/tests/mocha/unit/attribute-set.spec.ts
+++ b/lib/tests/mocha/unit/attribute-set.spec.ts
@@ -89,7 +89,7 @@ describe('AttributeSet', function () {
     assert.equal(aSet.attributes[0], expected);
   });
 
-  it('should not add one with additional fields (malformed)', () => {
+  it.skip('should not add one with additional fields (malformed)', () => {
     const aSet = new AttributeSet();
     const expected = Mocks.createAttribute({});
     expected.addedField = 'Potential mallware';
@@ -134,7 +134,7 @@ describe('AttributeSet', function () {
     assert.equal(aSet.attributes[0], expected);
   });
 
-  it('should not add an attribute object with "attribute" missing ', () => {
+  it.skip('should not add an attribute object with "attribute" missing ', () => {
     const aSet = new AttributeSet();
     const expected = Mocks.createAttribute({});
     delete expected.attribute;
@@ -142,7 +142,7 @@ describe('AttributeSet', function () {
     assert.equal(aSet.attributes.length, 0);
   });
 
-  it('should not add an attribute object with "pubKey" missing ', () => {
+  it.skip('should not add an attribute object with "pubKey" missing ', () => {
     const aSet = new AttributeSet();
     const expected = Mocks.createAttribute({});
     delete expected.pubKey;
@@ -150,7 +150,7 @@ describe('AttributeSet', function () {
     assert.equal(aSet.attributes.length, 0);
   });
 
-  it('should not add an attribute object with "kasUrl" missing ', () => {
+  it.skip('should not add an attribute object with "kasUrl" missing ', () => {
     const aSet = new AttributeSet();
     const expected = Mocks.createAttribute({});
     delete expected.kasUrl;

--- a/remote-store/package-lock.json
+++ b/remote-store/package-lock.json
@@ -1649,9 +1649,8 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-GDANpXzBtdu39GJSlGvLhjgkDF+zOUNVDAz4J/+28gZlDlbMjkjBkzmlA5cMl81k7+RWPnHTRdQ3T3pTY7A0Yg==",
+      "integrity": "sha512-/tSAwAhM6CKjk6T1xvBPloOncxQOImszfbYfZaFjOfE2lj9bQC1fIH+subEY0N/SbY7faIae6wjkjmXp9Xti5A==",
       "dependencies": {
-        "ajv": "^8.12.0",
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
         "base64-js": "^1.5.1",
@@ -2924,21 +2923,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -3612,7 +3596,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.0",
@@ -4191,11 +4176,6 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4802,6 +4782,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4937,14 +4918,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5401,6 +5374,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -602,9 +602,8 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-GDANpXzBtdu39GJSlGvLhjgkDF+zOUNVDAz4J/+28gZlDlbMjkjBkzmlA5cMl81k7+RWPnHTRdQ3T3pTY7A0Yg==",
+      "integrity": "sha512-/tSAwAhM6CKjk6T1xvBPloOncxQOImszfbYfZaFjOfE2lj9bQC1fIH+subEY0N/SbY7faIae6wjkjmXp9Xti5A==",
       "dependencies": {
-        "ajv": "^8.12.0",
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
         "base64-js": "^1.5.1",
@@ -617,26 +616,6 @@
         "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
       }
-    },
-    "node_modules/@opentdf/client/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@opentdf/client/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@playwright/test": {
       "version": "1.36.2",
@@ -1860,6 +1839,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2923,6 +2903,7 @@
     },
     "node_modules/punycode": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3031,14 +3012,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -3486,6 +3459,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -4099,9 +4073,8 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-GDANpXzBtdu39GJSlGvLhjgkDF+zOUNVDAz4J/+28gZlDlbMjkjBkzmlA5cMl81k7+RWPnHTRdQ3T3pTY7A0Yg==",
+      "integrity": "sha512-/tSAwAhM6CKjk6T1xvBPloOncxQOImszfbYfZaFjOfE2lj9bQC1fIH+subEY0N/SbY7faIae6wjkjmXp9Xti5A==",
       "requires": {
-        "ajv": "^8.12.0",
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
         "base64-js": "^1.5.1",
@@ -4113,24 +4086,6 @@
         "jose": "^4.14.4",
         "streamsaver": "^2.0.6",
         "uuid": "~9.0.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-          "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-          "requires": {
-            "fast-deep-equal": "^3.1.3",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.4.1"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-        }
       }
     },
     "@playwright/test": {
@@ -4863,7 +4818,8 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.3.0",
@@ -5491,7 +5447,8 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -5561,11 +5518,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -5817,6 +5769,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }


### PR DESCRIPTION
- We aren't doing attribute validation elsewhere
- This is less necessary after the switch to typescript
- the library is heavy and doesn't play well with our esm based tooling