### PR TITLE
updated to new policy binding format

### DIFF
--- a/lib/tdf3/src/models/key-access.ts
+++ b/lib/tdf3/src/models/key-access.ts
@@ -43,7 +43,10 @@ export class Wrapped {
       protocol: 'kas',
       wrappedKey: base64.encode(wrappedKeyBinary.asString()),
       encryptedMetadata: base64.encode(encryptedMetadataStr),
-      policyBinding: base64.encode(policyBinding),
+      policyBinding: {
+        alg: 'HS256',
+        hash: base64.encode(policyBinding)
+      },
     };
     if (this.kid) {
       this.keyAccessObject.kid = this.kid;
@@ -91,7 +94,10 @@ export class Remote {
       protocol: 'kas',
       wrappedKey: this.wrappedKey,
       encryptedMetadata: base64.encode(encryptedMetadataStr),
-      policyBinding: base64.encode(policyBinding),
+      policyBinding: {
+        alg: 'HS256',
+        hash: base64.encode(policyBinding)
+      },
     };
     if (this.kid) {
       this.keyAccessObject.kid = this.kid;
@@ -108,6 +114,9 @@ export type KeyAccessObject = {
   kid?: string;
   protocol: 'kas';
   wrappedKey?: string;
-  policyBinding?: string;
+  policyBinding?: {
+    alg: string,
+    hash: string
+  };
   encryptedMetadata?: string;
 };

--- a/lib/tdf3/src/models/key-access.ts
+++ b/lib/tdf3/src/models/key-access.ts
@@ -45,7 +45,7 @@ export class Wrapped {
       encryptedMetadata: base64.encode(encryptedMetadataStr),
       policyBinding: {
         alg: 'HS256',
-        hash: base64.encode(policyBinding)
+        hash: base64.encode(policyBinding),
       },
     };
     if (this.kid) {
@@ -96,7 +96,7 @@ export class Remote {
       encryptedMetadata: base64.encode(encryptedMetadataStr),
       policyBinding: {
         alg: 'HS256',
-        hash: base64.encode(policyBinding)
+        hash: base64.encode(policyBinding),
       },
     };
     if (this.kid) {
@@ -115,8 +115,8 @@ export type KeyAccessObject = {
   protocol: 'kas';
   wrappedKey?: string;
   policyBinding?: {
-    alg: string,
-    hash: string
+    alg: string;
+    hash: string;
   };
   encryptedMetadata?: string;
 };

--- a/lib/tests/mocks/client/default_manifest.json
+++ b/lib/tests/mocks/client/default_manifest.json
@@ -13,7 +13,10 @@
         "url": "http://kas.gsk.com:5000",
         "protocol": "kas",
         "wrappedKey": "OqnOETpwyGE3PVpUpwwWZoJTNW24UMhnXIif0mSnqLVCUPKAAhrjeue11uAXWpb9sD7ZDsmrc9ylmnSKP9vWel8ST68tv6PeVO+CPYUND7cqG2NhUHCLv5Ouys3Klurykvy8/O3cCLDYl6RDISosxFKqnd7LYD7VnxsYqUns4AW5/odXJrwIhNO3szZV0JgoBXs+U9bul4tSGNxmYuPOj0RE0HEX5yF5lWlt2vHNCqPlmSBV6+jePf7tOBBsqDq35GxCSHhFZhqCgA3MvnBLmKzVPArtJ1lqg3WUdnWV+o6BUzhDpOIyXzeKn4cK2mCxOXGMP2ck2C1a0sECyB82uw==",
-        "policyBinding": "BzmgoIxZzMmIF42qzbdD4Rw30GtdaRSQL2Xlfms1OPs=",
+        "policyBinding": {
+          "alg": "HS256",
+          "hash": "BzmgoIxZzMmIF42qzbdD4Rw30GtdaRSQL2Xlfms1OPs="
+        },
         "encryptedMetadata": "ZoJTNW24UMhnXIif0mSnqLVCU="
       }
     ],

--- a/lib/tests/mocks/tdf/0.manifest.json
+++ b/lib/tests/mocks/tdf/0.manifest.json
@@ -11,7 +11,10 @@
               "url": "http://127.0.0.1:4000",
               "protocol": "kas",
               "wrappedKey": "x8lk9Nxhx+zv+DVpCz89XLbMwbeeoNMhWIRO7CKdTNEWRWI9T+Ubkdvvi+SgrTJLQeEFBJspLQdombPI8Li1SVGD3pyfMNGXQ/FDoYIp2JHfyVKETfksU4q4gnNU3G63bTvCdQ41FeJJP26DIm63dKbF8BJQ/iSpXIPFalvMy/E9lR6kEv7ShKrwCKThFzynsg37ProbSmaYtTab+8J1/37oxm39PAUUfOOta9JA0mn8dz7f7a3nMVcXcyqrCTZSYbWKqhTowPeK2QiIfGJ1+K4F0V2UXMVuxIw6SEVbNL2hRkZ6+OSQd+kWMZTuneXtZeOHfBuOFRRzVzIEawagdA==",
-              "policyBinding": "fNPuURQu6ZpZk26TglgJxG1E7HiOynaFoyajj+8V1xg="
+              "policyBinding": {
+                "alg": "HS256",
+                "hash": "fNPuURQu6ZpZk26TglgJxG1E7HiOynaFoyajj+8V1xg="
+              }
             }
           ]
         ]


### PR DESCRIPTION
`policyBinding`
Object
This contains a keyed hash that will provide cryptographic integrity on the policy object, such that it cannot be modified or copied to another TDF, without invalidating the binding. Specifically, you would have to have access to the key in order to overwrite the policy. 

<p>This is Base64 encoding of HMAC(POLICY,KEY), where: <dl><dt>POLICY</dt><dd>`base64(policyjson)` that is in the “encryptionInformation/policy”</dd><dt>HMAC</dt><dd>HMAC SHA256 (default, but can be specified in the alg field described above)</dd><dt>KEY</dt><dd>Whichever Key Split or Key that is available to the KAS (e.g. the underlying AES 256 key in the wrappedKey.</dd></dl>

See https://github.com/opentdf/spec/blob/497a9f1808b2c50a50c63b86cd442ea61718766d/schema/tdf/KeyAccessObject.md?plain=1#L32