### PR TITLE
feat(core): NanoTDF resource locator protocol bit mask

### DIFF
--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -106,13 +106,15 @@ export default class ResourceLocator {
    * Construct URL from ResourceLocator or throw error
    */
   getUrl(): string | never {
-    let protocol;
-    if (this.protocol === ProtocolEnum.Http) {
+    let protocol: string;
+    // protocolIndex get the first four bits
+    const protocolIndex: number = this.protocol & 0xf;
+    if (protocolIndex === ProtocolEnum.Http) {
       protocol = 'http';
-    } else if (this.protocol === ProtocolEnum.Https) {
+    } else if (protocolIndex === ProtocolEnum.Https) {
       protocol = 'https';
     } else {
-      throw new Error(`Cannot create URL from protocol, ${ProtocolEnum[this.protocol]}`);
+      throw new Error(`Cannot create URL from protocol, "${ProtocolEnum[this.protocol]}"`);
     }
 
     return `${protocol}://${this.body}`;


### PR DESCRIPTION
Refactor the protocol determination logic to use bitwise operations for extracting protocol index. This change simplifies the code by directly using the lower four bits of the protocol to check for HTTP or HTTPS. Additionally, enhanced the error message formatting for better readability.

Issue: https://github.com/opentdf/platform/issues/1203
Specification: https://github.com/opentdf/spec/pull/40
ADR: https://github.com/opentdf/platform/issues/900