### PR TITLE
feat(core): KID in NanoTDF

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -39,6 +39,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
       "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -371,7 +372,8 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-C+R3AaydaZH21ODyr/DiMtmydWsyqjurecc8+Ai8jRwVyn3Cel+jGinu7rda1rPIBx1mOgkDg7HYdt3QKcZ8SA==",
+      "integrity": "sha512-0BJzWle4f2xoBKXYmifx0XLmYCn5A60cMuUBNG5inwKaLl+ES8gYgSHjx5ivsKsvv4dA8hW7SUPdjDeuxujchA==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
@@ -874,12 +876,14 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -890,6 +894,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
@@ -918,7 +923,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -942,12 +948,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -956,7 +963,8 @@
     "node_modules/browser-fs-access": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.34.1.tgz",
-      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ=="
+      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -982,6 +990,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -991,6 +1000,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1134,6 +1144,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1218,6 +1229,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1259,6 +1271,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
       "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1473,7 +1486,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1543,10 +1557,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1609,6 +1624,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1638,6 +1654,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1843,7 +1860,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.1",
@@ -1953,6 +1971,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1979,6 +1998,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2026,6 +2046,7 @@
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2222,6 +2243,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2230,6 +2252,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2635,7 +2658,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2746,7 +2770,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3030,7 +3055,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/jimmywarting"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3119,6 +3145,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -3268,6 +3295,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -67,12 +67,13 @@
       }
     },
     "node_modules/@75lb/deep-merge": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.1.tgz",
-      "integrity": "sha512-xvgv6pkMGBA6GwdyJbNAnDmfAIR/DfWhrj9jgWh3TY7gRm3KO46x/GPjRg6wJ0nOepwqrNxFfojebh0Df4h4Tw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@75lb/deep-merge/-/deep-merge-1.1.2.tgz",
+      "integrity": "sha512-08K9ou5VNbheZFxM5tDWoqjA3ImC50DiuuJ2tj1yEPRfkp8lLLg6XAaJ4On+a0yAXor/8ay5gHnAIshRM44Kpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "lodash.assignwith": "^4.2.0",
+        "lodash": "^4.17.21",
         "typical": "^7.1.1"
       },
       "engines": {
@@ -2481,10 +2482,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.1",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3746,7 +3749,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.0",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3758,15 +3763,17 @@
         "cookie": "~0.4.1",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.1.0",
-        "ws": "~8.11.0"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=10.2.0"
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.1.0",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3774,7 +3781,9 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.11.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3782,7 +3791,7 @@
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -6118,7 +6127,9 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.13.0",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6690,12 +6701,6 @@
       "version": "4.17.21",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.assignwith": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
-      "integrity": "sha512-ZznplvbvtjK2gMvnQ1BR/zqPFZmS6jbK4p+6Up4xcRYA7yMIwxHCfbTcrYxXKzzqLsQ05eJPVznEW3tuwV7k1g==",
-      "dev": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -8941,15 +8946,20 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.2",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ws": "~8.11.0"
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.11.0",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8957,7 +8967,7 @@
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -10232,7 +10242,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/lib/src/nanotdf/encrypt.ts
+++ b/lib/src/nanotdf/encrypt.ts
@@ -20,15 +20,16 @@ import {
  * Encrypt the plain data into nanotdf buffer
  *
  * @param policy Policy that will added to the nanotdf
- * @param kasPubCrtAsPem KAS public crt in pem format
- * @param kasUrl KAS url as string
+ * @param kasPub
+ * @param kasUrl KAS url as string or ResourceLocator
  * @param ephemeralKeyPair SDK ephemeral key pair to generate symmetric key
+ * @param iv
  * @param data The data to be encrypted
  */
 export default async function encrypt(
   policy: string,
   kasPub: CryptoKey,
-  kasUrl: string,
+  kasUrl: string | ResourceLocator,
   ephemeralKeyPair: CryptoKeyPair,
   iv: Uint8Array,
   data: string | TypedArray | ArrayBuffer
@@ -45,7 +46,12 @@ export default async function encrypt(
   );
 
   // Construct the kas locator
-  const kasResourceLocator = ResourceLocator.parse(kasUrl);
+  let kasResourceLocator;
+  if (kasUrl instanceof ResourceLocator) {
+    kasResourceLocator = kasUrl;
+  } else {
+    kasResourceLocator = ResourceLocator.parse(kasUrl);
+  }
 
   // Auth tag length for policy and payload
   const authTagLengthInBytes = authTagLengthForCipher(DefaultParams.symmetricCipher) / 8;

--- a/lib/src/nanotdf/enum/ProtocolEnum.ts
+++ b/lib/src/nanotdf/enum/ProtocolEnum.ts
@@ -1,8 +1,7 @@
 enum ProtocolEnum {
-  Http,
-  Https,
-  Unreserverd,
-  SharedResourceDirectory = 0xff,
+  Http = 0,
+  Https = 1,
+  SharedResourceDirectory = 0xf,
 }
 
 export default ProtocolEnum;

--- a/lib/src/nanotdf/enum/ResourceLocatorIdentifierEnum.ts
+++ b/lib/src/nanotdf/enum/ResourceLocatorIdentifierEnum.ts
@@ -1,0 +1,8 @@
+enum ResourceLocatorIdentifierEnum {
+  None = 0,
+  TwoBytes = 2,
+  EightBytes = 8,
+  ThirtyTwoBytes = 32,
+}
+
+export default ResourceLocatorIdentifierEnum;

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -1,4 +1,5 @@
 import ProtocolEnum from '../enum/ProtocolEnum.js';
+import ResourceLocatorIdentifierEnum from '../enum/ResourceLocatorIdentifierEnum.js';
 
 /**
  *
@@ -10,6 +11,7 @@ import ProtocolEnum from '../enum/ProtocolEnum.js';
  * | Protocol Enum | 1                  | 1                  |
  * | Body Length   | 1                  | 1                  |
  * | Body          | 1                  | 255                |
+ * | Identifier    | 0                  | n                  |
  *
  * @link https://github.com/virtru/nanotdf/blob/master/spec/index.md#3312-kas
  * @link https://github.com/virtru/nanotdf/blob/master/spec/index.md#341-resource-locator
@@ -18,6 +20,8 @@ export default class ResourceLocator {
   readonly protocol: ProtocolEnum;
   readonly lengthOfBody: number;
   readonly body: string;
+  readonly identifier: string;
+  readonly identifierType: ResourceLocatorIdentifierEnum = ResourceLocatorIdentifierEnum.None;
   readonly offset: number = 0;
 
   static readonly PROTOCOL_OFFSET = 0;
@@ -26,39 +30,90 @@ export default class ResourceLocator {
   static readonly LENGTH_LENGTH = 1;
   static readonly BODY_OFFSET = 2;
 
-  static parse(url: string): ResourceLocator {
+  static parse(url: string, identifier: string = ''): ResourceLocator {
     const [protocol, body] = url.split('://');
-
-    // Buffer to hold the protocol, length of body, body
-    const buffer = new Uint8Array(1 + 1 + body.length);
-    buffer.set([body.length], 1);
-    buffer.set(new TextEncoder().encode(body), 2);
-
+    const bodyLength = body.length;
+    const identifierLength = identifier.length;
+    let identifierPaddedLength = 0;
+    // protocol and identifier byte
+    const protocolIdentifierByte = new Uint8Array(1);
     if (protocol.toLowerCase() == 'http') {
-      buffer.set([ProtocolEnum.Http], 0);
+      protocolIdentifierByte[0] = protocolIdentifierByte[0] & 0x0f;
     } else if (protocol.toLowerCase() == 'https') {
-      buffer.set([ProtocolEnum.Https], 0);
+      protocolIdentifierByte[0] = (protocolIdentifierByte[0] & 0x0f) | 0b0010;
     } else {
       throw new Error('Resource locator protocol is not supported.');
     }
-
+    if (identifierLength === 0) {
+      protocolIdentifierByte[0] = (protocolIdentifierByte[0] & 0xf0) | 0b0000;
+    } else if (identifierLength <= 2) {
+      protocolIdentifierByte[0] = (protocolIdentifierByte[0] & 0xf0) | 0b0010;
+      identifierPaddedLength = ResourceLocatorIdentifierEnum.TwoBytes.valueOf();
+    } else if (identifierLength <= 8) {
+      protocolIdentifierByte[0] = (protocolIdentifierByte[0] & 0xf0) | 0b0100;
+      identifierPaddedLength = ResourceLocatorIdentifierEnum.EightBytes.valueOf();
+    } else if (identifierLength <= 32) {
+      protocolIdentifierByte[0] = (protocolIdentifierByte[0] & 0xf0) | 0b1000;
+      identifierPaddedLength = ResourceLocatorIdentifierEnum.ThirtyTwoBytes.valueOf();
+    } else {
+      throw new Error('Unsupported identifier length: ' + identifierLength);
+    }
+    // Buffer to hold the protocol, length of body, body, and identifierPadded
+    const buffer = new Uint8Array(1 + 1 + bodyLength + identifierPaddedLength);
+    buffer.set(protocolIdentifierByte, 0);
+    buffer.set([bodyLength], 1);
+    buffer.set(new TextEncoder().encode(body), 2);
+    // add padded identifier
+    if (identifierPaddedLength > 0) {
+      const identifierArray = new Uint8Array(identifierPaddedLength);
+      const encodedIdentifier = new TextEncoder()
+        .encode(identifier)
+        .subarray(0, identifierPaddedLength);
+      identifierArray.set(encodedIdentifier);
+      buffer.set(identifierArray, 2 + bodyLength);
+    }
     return new ResourceLocator(buffer);
   }
 
   constructor(buff: Uint8Array) {
     // Protocol
     this.protocol = buff[ResourceLocator.PROTOCOL_OFFSET];
-
     // Length of body
     this.lengthOfBody = buff[ResourceLocator.LENGTH_OFFSET];
-
     // Body as utf8 string
     const decoder = new TextDecoder();
     this.body = decoder.decode(
       buff.subarray(ResourceLocator.BODY_OFFSET, ResourceLocator.BODY_OFFSET + this.lengthOfBody)
     );
+    // identifier
+    const identifierTypeNibble = this.protocol & 0xf;
+    if ((identifierTypeNibble & 0b0010) !== 0) {
+      this.identifierType = ResourceLocatorIdentifierEnum.TwoBytes;
+    } else if ((identifierTypeNibble & 0b0100) !== 0) {
+      this.identifierType = ResourceLocatorIdentifierEnum.EightBytes;
+    } else if ((identifierTypeNibble & 0b1000) !== 0) {
+      this.identifierType = ResourceLocatorIdentifierEnum.ThirtyTwoBytes;
+    }
+    switch (this.identifierType) {
+      case ResourceLocatorIdentifierEnum.None:
+        // noop
+        break;
+      case ResourceLocatorIdentifierEnum.TwoBytes:
+      case ResourceLocatorIdentifierEnum.EightBytes:
+      case ResourceLocatorIdentifierEnum.ThirtyTwoBytes:
+        const start = ResourceLocator.BODY_OFFSET + this.lengthOfBody;
+        const end = start + this.identifierType.valueOf();
+        const subarray = buff.subarray(start, end);
+        // Remove padding (assuming the padding is null bytes, 0x00)
+        const trimmedSubarray = subarray.filter((byte) => byte !== 0x00);
+        this.identifier = decoder.decode(trimmedSubarray);
+        break;
+    }
     this.offset =
-      ResourceLocator.PROTOCOL_LENGTH + ResourceLocator.LENGTH_LENGTH + this.lengthOfBody;
+      ResourceLocator.PROTOCOL_LENGTH +
+      ResourceLocator.LENGTH_LENGTH +
+      this.lengthOfBody +
+      this.identifierType.valueOf();
   }
 
   /**
@@ -73,7 +128,9 @@ export default class ResourceLocator {
       // Length of the body( 1 byte)
       1 +
       // Content length
-      this.body.length
+      this.body.length +
+      // Identifier length
+      this.identifierType.valueOf()
     );
   }
 
@@ -92,11 +149,13 @@ export default class ResourceLocator {
    * Return the contents of the Resource Locator in buffer
    */
   toBuffer(): Uint8Array {
-    const buffer = new Uint8Array(2 + this.body.length);
+    const buffer = new Uint8Array(2 + this.body.length + this.identifierType.valueOf());
     buffer.set([this.protocol], 0);
     buffer.set([this.lengthOfBody], 1);
     buffer.set(new TextEncoder().encode(this.body), 2);
-
+    if (this.identifier) {
+      buffer.set(new TextEncoder().encode(this.identifier), 2 + this.body.length);
+    }
     return buffer;
   }
 
@@ -116,7 +175,16 @@ export default class ResourceLocator {
     } else {
       throw new Error(`Cannot create URL from protocol, "${ProtocolEnum[this.protocol]}"`);
     }
-
     return `${protocol}://${this.body}`;
+  }
+
+  /**
+   * Get Identifier
+   *
+   * Returns the identifier of the ResourceLocator or an empty string if no identifier is present.
+   * @returns { string } Identifier of the resource locator.
+   */
+  getIdentifier(): string {
+    return this.identifier || '';
   }
 }

--- a/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
+++ b/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
@@ -1,4 +1,4 @@
-import { expect } from '@esm-bundle/chai';
+import { assert, expect } from '@esm-bundle/chai';
 import { NanoTDF } from '../../../src/nanotdf/index.js';
 import PolicyTypeEnum from '../../../src/nanotdf/enum/PolicyTypeEnum.js';
 import bufferToHex from './helpers/bufferToHex.js';
@@ -7,8 +7,24 @@ import * as remoteFixture from '../../__fixtures__/nanotdf-spec-remote-example.j
 import * as embeddedFixture from '../../__fixtures__/nanotdf-spec-embedded-example.js';
 import * as plainEmbeddedFixture from '../../__fixtures__/nanotdf-spec-plain-embedded-example.js';
 import { EmbeddedHeader, PlainEmbeddedHeader, RemoteHeader } from '../../../src/types/index.js';
+import ResourceLocator from '../../../src/nanotdf/models/ResourceLocator.js';
+import ResourceLocatorIdentifierEnum from '../../../src/nanotdf/enum/ResourceLocatorIdentifierEnum.js';
 
 describe('NanoTDF', () => {
+  it('should parse the ResourceLocator Identifier', () => {
+    let rl = ResourceLocator.parse('http://localhost:8080', 'e0');
+    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.TwoBytes);
+    assert.equal(rl.getIdentifier(), 'e0');
+    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0');
+    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.EightBytes);
+    assert.equal(rl.getIdentifier(), 'e0e0e0e0');
+    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
+    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.ThirtyTwoBytes);
+    assert.equal(rl.getIdentifier(), 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
+    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0');
+    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.ThirtyTwoBytes);
+    assert.equal(rl.getIdentifier(), 'e0e0e0e0e0e0e0e0');
+  });
   for (const { policyType, fixture } of [
     { policyType: PolicyTypeEnum.Remote, fixture: remoteFixture },
     { policyType: PolicyTypeEnum.EmbeddedText, fixture: embeddedFixture },

--- a/remote-store/package-lock.json
+++ b/remote-store/package-lock.json
@@ -1536,9 +1536,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1820,7 +1821,8 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-9vExrKuqDY1CHmyy2Z7umlwZRFSI08JjkStzkkTrKRF91hEcBEHRvthuFIplNyX5NRZ85i8AXJCcCoDZLgshsg==",
+      "integrity": "sha512-0BJzWle4f2xoBKXYmifx0XLmYCn5A60cMuUBNG5inwKaLl+ES8gYgSHjx5ivsKsvv4dA8hW7SUPdjDeuxujchA==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
@@ -3286,11 +3288,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3299,6 +3302,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
@@ -3327,7 +3331,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -3368,7 +3373,8 @@
     "node_modules/browser-fs-access": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.34.1.tgz",
-      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ=="
+      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -3394,6 +3400,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -3403,6 +3410,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3633,9 +3641,10 @@
       }
     },
     "node_modules/dpop": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.0.tgz",
-      "integrity": "sha512-r//f6g3uaDdomkz+3M0NdcEAxSGUVMIhF7lxf06aJZjCFhkH//GeZo6JWpz7Uv025s1w/+M5RDNRGxAGNIzm0g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
+      "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3863,7 +3872,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4240,7 +4250,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -4377,6 +4388,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4421,9 +4433,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5183,7 +5196,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5427,7 +5441,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/jimmywarting"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -350,9 +350,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -606,7 +607,8 @@
     "node_modules/@opentdf/client": {
       "version": "2.0.0",
       "resolved": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-9vExrKuqDY1CHmyy2Z7umlwZRFSI08JjkStzkkTrKRF91hEcBEHRvthuFIplNyX5NRZ85i8AXJCcCoDZLgshsg==",
+      "integrity": "sha512-0BJzWle4f2xoBKXYmifx0XLmYCn5A60cMuUBNG5inwKaLl+ES8gYgSHjx5ivsKsvv4dA8hW7SUPdjDeuxujchA==",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
@@ -1184,12 +1186,14 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1200,6 +1204,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
       "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "is-retry-allowed": "^2.2.0"
@@ -1238,11 +1243,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1251,7 +1258,8 @@
     "node_modules/browser-fs-access": {
       "version": "0.34.1",
       "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.34.1.tgz",
-      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ=="
+      "integrity": "sha512-HPaRf2yimp8kWSuWJXc8Mi78dPbDzfduA+Gyq14H4jlMvd6XNfIRm36Y2yRLaa4x0gwcGuepj4zf14oiTlxrxQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/browserslist": {
       "version": "4.21.10",
@@ -1310,6 +1318,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1411,6 +1420,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1490,6 +1500,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1534,9 +1545,10 @@
       }
     },
     "node_modules/dpop": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.0.tgz",
-      "integrity": "sha512-r//f6g3uaDdomkz+3M0NdcEAxSGUVMIhF7lxf06aJZjCFhkH//GeZo6JWpz7Uv025s1w/+M5RDNRGxAGNIzm0g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
+      "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1839,7 +1851,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1929,7 +1942,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1981,6 +1996,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -1994,6 +2010,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2227,6 +2244,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2245,6 +2264,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2258,9 +2278,10 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2464,6 +2485,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2472,6 +2494,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -2903,7 +2926,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -3015,7 +3039,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -3256,7 +3281,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/jimmywarting"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -3349,6 +3375,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3482,6 +3510,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3496,10 +3525,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -3921,9 +3951,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
+      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -4081,7 +4111,7 @@
     },
     "@opentdf/client": {
       "version": "file:../lib/opentdf-client-2.0.0.tgz",
-      "integrity": "sha512-9vExrKuqDY1CHmyy2Z7umlwZRFSI08JjkStzkkTrKRF91hEcBEHRvthuFIplNyX5NRZ85i8AXJCcCoDZLgshsg==",
+      "integrity": "sha512-0BJzWle4f2xoBKXYmifx0XLmYCn5A60cMuUBNG5inwKaLl+ES8gYgSHjx5ivsKsvv4dA8hW7SUPdjDeuxujchA==",
       "requires": {
         "axios": "^1.6.1",
         "axios-retry": "^3.9.0",
@@ -4429,9 +4459,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4463,10 +4493,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-fs-access": {
@@ -4631,9 +4663,9 @@
       }
     },
     "dpop": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.0.tgz",
-      "integrity": "sha512-r//f6g3uaDdomkz+3M0NdcEAxSGUVMIhF7lxf06aJZjCFhkH//GeZo6JWpz7Uv025s1w/+M5RDNRGxAGNIzm0g=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dpop/-/dpop-1.4.1.tgz",
+      "integrity": "sha512-+Cus+OlLk9uFWbPZX/RsLpMviYAmyJpJpooto2NDQ0lnk0/S2TblPunC4nVtETOxCIsXvu4YILIOPC7LIHHXIg=="
     },
     "electron-to-chromium": {
       "version": "1.4.477",
@@ -4884,7 +4916,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -5055,6 +5089,8 @@
     },
     "is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-path-inside": {
@@ -5071,9 +5107,9 @@
       "dev": true
     },
     "jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg=="
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="
     },
     "js-tokens": {
       "version": "4.0.0"
@@ -5726,6 +5762,8 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
@@ -5800,9 +5838,9 @@
       }
     },
     "vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",


### PR DESCRIPTION
NanoTDF will now have the KAS KID set in the KAS ResourceLocator

To set the KAS KID the end-developer is must set it in `ResourceLocator.parse(kasUrl, id)` and pass it to encrypt() instead of kasUrl String

Introduces a new enum for identifier length and modifies the ResourceLocator class to include this identifier and its encoding/decoding logic. This enhances the resource locator functionality by supporting identifiers of varying lengths.

Resolves https://github.com/opentdf/client-web/issues/311
Specification: https://github.com/opentdf/spec/pull/40
ADR: https://github.com/opentdf/platform/issues/900

see also https://github.com/opentdf/client-web/pull/324