### PR TITLE
fix(nano): Fixes `url` property when with kid

### DIFF
--- a/lib/src/encodings/hex.ts
+++ b/lib/src/encodings/hex.ts
@@ -1,17 +1,49 @@
+import { InvalidCharacterError } from './base64.js';
+
 export function encode(str: string): string {
   let hex = '';
   for (let i = 0; i < str.length; i++) {
-    hex += `${str.charCodeAt(i).toString(16)}`;
+    const s = str.charCodeAt(i).toString(16);
+    if (s.length < 2) {
+      hex += '0' + s;
+    } else if (s.length > 2) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 1)}]`);
+    } else {
+      hex += `${s}`;
+    }
   }
   return hex;
 }
 
 export function decode(hex: string): string {
+  if (hex.length & 1) {
+    throw new InvalidCharacterError('invalid input.');
+  }
   let str = '';
   for (let i = 0; i < hex.length; i += 2) {
-    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+    const b = parseInt(hex.substring(i, i + 2), 16);
+    if (isNaN(b)) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 2)}]`);
+    }
+    str += String.fromCharCode(b);
   }
   return str;
+}
+
+export function decodeArrayBuffer(hex: string): ArrayBuffer | never {
+  const binLength = hex.length >> 1; // 1 byte per 2 characters
+  if (hex.length & 1) {
+    throw new InvalidCharacterError('invalid input.');
+  }
+  const bytes = new Uint8Array(binLength);
+  for (let i = 0; i < hex.length; i += 2) {
+    const b = parseInt(hex.substring(i, i + 2), 16);
+    if (isNaN(b)) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 2)}]`);
+    }
+    bytes[i >> 1] = b;
+  }
+  return bytes.buffer;
 }
 
 export function encodeArrayBuffer(arrayBuffer: ArrayBuffer): string | never {

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -47,7 +47,7 @@ export default class ResourceLocator {
         protocolIdentifierByte[0] = 0x01;
         break;
       default:
-        throw new Error('Resource locator protocol is not supported.');
+        throw new Error('resource locator protocol unsupported');
     }
 
     // Set identifier padded length and protocol identifier byte
@@ -149,7 +149,7 @@ export default class ResourceLocator {
   }
 
   get url(): string | never {
-    switch (this.protocol) {
+    switch (this.protocol & 0xf) {
       case ProtocolEnum.Http:
         return 'http://' + this.body;
       case ProtocolEnum.Https:

--- a/lib/tests/web/encodings/hex.test.ts
+++ b/lib/tests/web/encodings/hex.test.ts
@@ -3,12 +3,74 @@ import { expect } from '@esm-bundle/chai';
 import * as hex from '../../../src/encodings/hex.js';
 
 describe('hex', function () {
-  it('encodes', function () {
-    const encodedString = hex.encode('Hello world');
-    expect(encodedString).to.eql('48656c6c6f20776f726c64');
+  describe('encode', function () {
+    for (const { g, e } of [
+      { g: 'Hello world', e: '48656c6c6f20776f726c64' },
+      { g: '', e: '' },
+      { g: ' ', e: '20' },
+      { g: '\u0000', e: '00' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.encode(g)).to.eql(e);
+      });
+    }
   });
-  it('decodes', function () {
-    const string = hex.decode('466f6f');
-    expect(string).to.eql('Foo');
+  describe('encode throws', function () {
+    for (const { g, e } of [
+      { g: '🚩🚩🚩', e: 'invalid input' },
+      { g: '\uffff', e: 'invalid input' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(() => hex.encode(g)).to.throw(e);
+      });
+    }
+  });
+  describe('encodeArrayBuffer', function () {
+    for (const { g, e } of [
+      { g: [], e: '' },
+      { g: [0], e: '00' },
+      { g: [255], e: 'ff' },
+      { g: [255, 0, 32], e: 'ff0020' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.encodeArrayBuffer(new Uint8Array(g).buffer)).to.eql(e);
+      });
+    }
+  });
+
+  describe('decode', function () {
+    for (const { g, e } of [
+      { g: '48656c6c6f20776f726c64', e: 'Hello world' },
+      { g: '', e: '' },
+      { g: '20', e: ' ' },
+      { g: '466f6f', e: 'Foo' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.decode(g)).to.eql(e);
+      });
+    }
+  });
+  describe('decode throws', function () {
+    for (const { g, e } of [
+      { g: '🚩🚩🚩', e: 'invalid input' },
+      { g: 'ff ff', e: 'invalid input' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(() => hex.decode(g)).to.throw(e);
+        expect(() => hex.decodeArrayBuffer(g)).to.throw(e);
+      });
+    }
+  });
+  describe('decodeArrayBuffer', function () {
+    for (const { g, e } of [
+      { g: '', e: [] },
+      { g: '00', e: [0] },
+      { g: 'ff', e: [255] },
+      { g: 'ff0020', e: [255, 0, 32] },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.decodeArrayBuffer(g)).to.eql(new Uint8Array(e).buffer);
+      });
+    }
   });
 });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -1,0 +1,54 @@
+import { expect } from '@esm-bundle/chai';
+
+import ResourceLocator from '../../../../src/nanotdf/models/ResourceLocator.js';
+import ResourceLocatorIdentifierEnum from '../../../../src/nanotdf/enum/ResourceLocatorIdentifierEnum.js';
+import { hex } from '../../../../src/encodings/index.js';
+
+describe('NanoTDF.ResourceLocator', () => {
+  for (const { u, kid, idt } of [
+    { u: 'http://a', idt: ResourceLocatorIdentifierEnum.None },
+    { u: 'http://a', kid: 'r1', idt: ResourceLocatorIdentifierEnum.TwoBytes },
+    { u: 'http://a', kid: '12345678', idt: ResourceLocatorIdentifierEnum.EightBytes },
+    {
+      u: 'http://a',
+      kid: '12345678901234567890123456789012',
+      idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
+    },
+  ]) {
+    it(`ResourceLocator.parse("${u}", "${kid}")`, () => {
+      const rl = ResourceLocator.parse(u, kid);
+      expect(rl).to.have.property('identifierType', idt);
+      expect(rl).to.have.property('identifier', kid);
+    });
+  }
+
+  for (const { u, kid, v } of [
+    { u: 'http://a', v: '00 01 61' },
+    { u: 'https://a', v: '01 01 61' },
+    { u: 'http://a', kid: 'r1', v: '10 01 61 72 31' },
+    { u: 'https://a', kid: 'r1', v: '11 01 61 72 31' },
+    { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
+    {
+      u: 'http://a',
+      kid: '12345678901234567890123456789012',
+      v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32',
+    },
+  ]) {
+    it(`new ResourceLocator("${u}", "${kid}")`, () => {
+      const hexValue = v.replace(/\s/g, '');
+      const ab = hex.decodeArrayBuffer(hexValue);
+      const rl = new ResourceLocator(new Uint8Array(ab));
+      expect(rl).to.have.property('identifier', kid);
+      expect(rl).to.have.property('url', u);
+    });
+  }
+
+  for (const { u, kid, msg } of [
+    { u: 'http://a', kid: 'e0e0e0e0e0e0e0e0', msg: 'Unsupported identifier length: 16' },
+    { u: 'gopher://a', kid: 'r1', msg: 'protocol unsupported' },
+  ]) {
+    it(`invalid resource locator`, () => {
+      expect(() => ResourceLocator.parse(u, kid)).throw(msg);
+    });
+  }
+});

--- a/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
+++ b/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from '@esm-bundle/chai';
+import { expect } from '@esm-bundle/chai';
 import { NanoTDF } from '../../../src/nanotdf/index.js';
 import PolicyTypeEnum from '../../../src/nanotdf/enum/PolicyTypeEnum.js';
 import bufferToHex from './helpers/bufferToHex.js';
@@ -7,24 +7,8 @@ import * as remoteFixture from '../../__fixtures__/nanotdf-spec-remote-example.j
 import * as embeddedFixture from '../../__fixtures__/nanotdf-spec-embedded-example.js';
 import * as plainEmbeddedFixture from '../../__fixtures__/nanotdf-spec-plain-embedded-example.js';
 import { EmbeddedHeader, PlainEmbeddedHeader, RemoteHeader } from '../../../src/types/index.js';
-import ResourceLocator from '../../../src/nanotdf/models/ResourceLocator.js';
-import ResourceLocatorIdentifierEnum from '../../../src/nanotdf/enum/ResourceLocatorIdentifierEnum.js';
 
 describe('NanoTDF', () => {
-  it('should parse the ResourceLocator Identifier', () => {
-    let rl = ResourceLocator.parse('http://localhost:8080', 'e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.TwoBytes);
-    assert.equal(rl.getIdentifier(), 'e0');
-    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.EightBytes);
-    assert.equal(rl.getIdentifier(), 'e0e0e0e0');
-    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.ThirtyTwoBytes);
-    assert.equal(rl.getIdentifier(), 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
-    expect(() => ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0')).throw(
-      'Unsupported identifier length: 16'
-    );
-  });
   for (const { policyType, fixture } of [
     { policyType: PolicyTypeEnum.Remote, fixture: remoteFixture },
     { policyType: PolicyTypeEnum.EmbeddedText, fixture: embeddedFixture },


### PR DESCRIPTION
- Adds several tests for ResourceLocator
- Since the unit tests I've added use the hex encoding for ease of reading, this change also updates the hex encoding functions and greatly increases test coverage for them