### PR TITLE
fix(nano): Store kid

### DIFF
--- a/lib/src/encodings/hex.ts
+++ b/lib/src/encodings/hex.ts
@@ -1,17 +1,49 @@
+import { InvalidCharacterError } from './base64.js';
+
 export function encode(str: string): string {
   let hex = '';
   for (let i = 0; i < str.length; i++) {
-    hex += `${str.charCodeAt(i).toString(16)}`;
+    const s = str.charCodeAt(i).toString(16);
+    if (s.length < 2) {
+      hex += '0' + s;
+    } else if (s.length > 2) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 1)}]`);
+    } else {
+      hex += `${s}`;
+    }
   }
   return hex;
 }
 
 export function decode(hex: string): string {
+  if (hex.length & 1) {
+    throw new InvalidCharacterError('invalid input.');
+  }
   let str = '';
   for (let i = 0; i < hex.length; i += 2) {
-    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+    const b = parseInt(hex.substring(i, i + 2), 16);
+    if (isNaN(b)) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 2)}]`);
+    }
+    str += String.fromCharCode(b);
   }
   return str;
+}
+
+export function decodeArrayBuffer(hex: string): ArrayBuffer | never {
+  const binLength = hex.length >> 1; // 1 byte per 2 characters
+  if (hex.length & 1) {
+    throw new InvalidCharacterError('invalid input.');
+  }
+  const bytes = new Uint8Array(binLength);
+  for (let i = 0; i < hex.length; i += 2) {
+    const b = parseInt(hex.substring(i, i + 2), 16);
+    if (isNaN(b)) {
+      throw new InvalidCharacterError(`invalid input at char ${i} == [${hex.substring(i, i + 2)}]`);
+    }
+    bytes[i >> 1] = b;
+  }
+  return bytes.buffer;
 }
 
 export function encodeArrayBuffer(arrayBuffer: ArrayBuffer): string | never {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -155,14 +155,7 @@ export class NanoTDFClient extends Client {
     payloadIV[10] = lengthAsUint24[1];
     payloadIV[11] = lengthAsUint24[0];
 
-    return encrypt(
-      policyObjectAsStr,
-      this.kasPubKey,
-      this.kasUrl,
-      ephemeralKeyPair,
-      payloadIV,
-      data
-    );
+    return encrypt(policyObjectAsStr, this.kasPubKey, ephemeralKeyPair, payloadIV, data);
   }
 }
 
@@ -274,14 +267,13 @@ export class NanoTDFDatasetClient extends Client {
       // Generate a symmetric key.
       this.symmetricKey = await keyAgreement(
         ephemeralKeyPair.privateKey,
-        this.kasPubKey,
+        await this.kasPubKey.key,
         await getHkdfSalt(DefaultParams.magicNumberVersion)
       );
 
       const nanoTDFBuffer = await encrypt(
         policyObjectAsStr,
         this.kasPubKey,
-        this.kasUrl,
         ephemeralKeyPair,
         ivVector,
         data

--- a/lib/src/nanotdf/Client.ts
+++ b/lib/src/nanotdf/Client.ts
@@ -3,7 +3,7 @@ import * as base64 from '../encodings/base64.js';
 import { generateKeyPair, keyAgreement } from '../nanotdf-crypto/index.js';
 import getHkdfSalt from './helpers/getHkdfSalt.js';
 import DefaultParams from './models/DefaultParams.js';
-import { fetchWrappedKey, OriginAllowList } from '../access.js';
+import { fetchWrappedKey, KasPublicKeyInfo, OriginAllowList } from '../access.js';
 import { AuthProvider, isAuthProvider, reqSignature } from '../auth/providers.js';
 import { UnsafeUrlError } from '../errors.js';
 import { cryptoPublicToPem, pemToCryptoPublicKey, validateSecureUrl } from '../utils.js';
@@ -106,7 +106,7 @@ export default class Client {
     This is needed as the flow is very specific. Errors should be thrown if the necessary step is not completed.
   */
   protected kasUrl: string;
-  kasPubKey?: CryptoKey;
+  kasPubKey?: KasPublicKeyInfo;
   readonly authProvider: AuthProvider;
   readonly dpopEnabled: boolean;
   dissems: string[] = [];
@@ -341,6 +341,7 @@ export default class Client {
 
       return unwrappedKey;
     } catch (cause) {
+      console.error('rewrap fail', cause);
       throw new Error('Could not rewrap key with entity object.', { cause });
     }
   }

--- a/lib/src/nanotdf/encrypt.ts
+++ b/lib/src/nanotdf/encrypt.ts
@@ -15,21 +15,20 @@ import {
   digest,
   exportCryptoKey,
 } from '../nanotdf-crypto/index.js';
+import { KasPublicKeyInfo } from '../access.js';
 
 /**
  * Encrypt the plain data into nanotdf buffer
  *
  * @param policy Policy that will added to the nanotdf
- * @param kasPub
- * @param kasUrl KAS url as string or ResourceLocator
+ * @param kasInfo KAS url and public key data
  * @param ephemeralKeyPair SDK ephemeral key pair to generate symmetric key
  * @param iv
  * @param data The data to be encrypted
  */
 export default async function encrypt(
   policy: string,
-  kasPub: CryptoKey,
-  kasUrl: string | ResourceLocator,
+  kasInfo: KasPublicKeyInfo,
   ephemeralKeyPair: CryptoKeyPair,
   iv: Uint8Array,
   data: string | TypedArray | ArrayBuffer
@@ -40,17 +39,17 @@ export default async function encrypt(
   }
   const symmetricKey = await keyAgreement(
     ephemeralKeyPair.privateKey,
-    kasPub,
+    await kasInfo.key,
     // Get the hkdf salt params
     await getHkdfSalt(DefaultParams.magicNumberVersion)
   );
 
   // Construct the kas locator
   let kasResourceLocator;
-  if (kasUrl instanceof ResourceLocator) {
-    kasResourceLocator = kasUrl;
+  if (kasInfo.kid) {
+    kasResourceLocator = ResourceLocator.parse(kasInfo.url, kasInfo.kid);
   } else {
-    kasResourceLocator = ResourceLocator.parse(kasUrl);
+    kasResourceLocator = ResourceLocator.parse(kasInfo.url);
   }
 
   // Auth tag length for policy and payload

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -47,7 +47,7 @@ export default class ResourceLocator {
         protocolIdentifierByte[0] = 0x01;
         break;
       default:
-        throw new Error('Resource locator protocol is not supported.');
+        throw new Error('resource locator protocol unsupported');
     }
 
     // Set identifier padded length and protocol identifier byte
@@ -149,7 +149,7 @@ export default class ResourceLocator {
   }
 
   get url(): string | never {
-    switch (this.protocol) {
+    switch (this.protocol & 0xf) {
       case ProtocolEnum.Http:
         return 'http://' + this.body;
       case ProtocolEnum.Https:

--- a/lib/src/tdf/AttributeObject.ts
+++ b/lib/src/tdf/AttributeObject.ts
@@ -1,4 +1,4 @@
-import { cryptoPublicToPem } from '../utils.js';
+import { type KasPublicKeyInfo } from '../access.js';
 
 export interface AttributeObject {
   readonly attribute: string;
@@ -13,14 +13,14 @@ export interface AttributeObject {
 
 export async function createAttribute(
   attribute: string,
-  pubKey: CryptoKey,
+  pubKey: KasPublicKeyInfo,
   kasUrl: string
 ): Promise<AttributeObject> {
   return {
     attribute,
     isDefault: false,
     displayName: '',
-    pubKey: await cryptoPublicToPem(pubKey),
+    pubKey: pubKey.publicKey,
     kasUrl,
     schemaVersion: '1.1.0',
   };

--- a/lib/tdf3/src/client/index.ts
+++ b/lib/tdf3/src/client/index.ts
@@ -14,7 +14,6 @@ import {
   buildKeyAccess,
   EncryptConfiguration,
   fetchKasPublicKey,
-  KasPublicKeyInfo,
   unwrapHtml,
   validatePolicyObject,
   readStream,
@@ -31,7 +30,7 @@ import {
   withHeaders,
 } from '../../../src/auth/auth.js';
 import EAS from '../../../src/auth/Eas.js';
-import { cryptoPublicToPem, validateSecureUrl } from '../../../src/utils.js';
+import { cryptoPublicToPem, pemToCryptoPublicKey, validateSecureUrl } from '../../../src/utils.js';
 
 import {
   EncryptParams,
@@ -50,7 +49,7 @@ import {
   type DecryptSource,
   EncryptParamsBuilder,
 } from './builders.js';
-import { OriginAllowList } from '../../../src/access.js';
+import { KasPublicKeyInfo, OriginAllowList } from '../../../src/access.js';
 import { TdfError } from '../../../src/errors.js';
 import { EntityObject } from '../../../src/tdf/EntityObject.js';
 import { Binary } from '../binary.js';
@@ -337,6 +336,7 @@ export class Client {
       this.kasKeys[this.kasEndpoint] = Promise.resolve({
         url: this.kasEndpoint,
         algorithm: 'rsa:2048',
+        key: pemToCryptoPublicKey(clientConfig.kasPublicKey),
         publicKey: clientConfig.kasPublicKey,
       });
     }

--- a/lib/tdf3/src/tdf.ts
+++ b/lib/tdf3/src/tdf.ts
@@ -3,7 +3,7 @@ import { unsigned } from './utils/buffer-crc32.js';
 import { exportSPKI, importX509 } from 'jose';
 import { DecoratedReadableStream } from './client/DecoratedReadableStream.js';
 import { EntityObject } from '../../src/tdf/EntityObject.js';
-import { validateSecureUrl } from '../../src/utils.js';
+import { pemToCryptoPublicKey, validateSecureUrl } from '../../src/utils.js';
 import { DecryptParams } from './client/builders.js';
 
 import {
@@ -33,7 +33,7 @@ import {
   concatUint8,
 } from './utils/index.js';
 import { Binary } from './binary.js';
-import { OriginAllowList } from '../../src/access.js';
+import { KasPublicKeyAlgorithm, KasPublicKeyInfo, OriginAllowList } from '../../src/access.js';
 import {
   IllegalArgumentError,
   KasDecryptError,
@@ -176,15 +176,6 @@ export type RewrapRequest = {
   signedRequestToken: string;
 };
 
-export type KasPublicKeyInfo = {
-  url: string;
-  algorithm: KasPublicKeyAlgorithm;
-  kid?: string;
-  publicKey: string;
-};
-
-export type KasPublicKeyAlgorithm = 'ec:secp256r1' | 'rsa:2048';
-
 export type KasPublicKeyFormat = 'pkcs8' | 'jwks';
 
 type KasPublicKeyParams = {
@@ -229,6 +220,7 @@ export async function fetchKasPublicKey(
         : response.data.publicKey;
     return {
       publicKey,
+      key: pemToCryptoPublicKey(publicKey),
       ...infoStatic,
       ...(typeof response.data !== 'string' && response.data.kid && { kid: response.data.kid }),
     };
@@ -252,6 +244,7 @@ export async function fetchKasPublicKey(
     // future proof: allow v2 response even if not specified.
     return {
       publicKey,
+      key: pemToCryptoPublicKey(publicKey),
       ...infoStatic,
       ...(typeof response.data !== 'string' && response.data.kid && { kid: response.data.kid }),
     };

--- a/lib/tests/mocha/unit/tdf.spec.ts
+++ b/lib/tests/mocha/unit/tdf.spec.ts
@@ -91,7 +91,7 @@ describe('fetchKasPublicKey', async () => {
   it('localhost kas is valid', async () => {
     const pk2 = await TDF.fetchKasPublicKey('http://localhost:3000');
     expect(pk2.publicKey).to.include('BEGIN CERTIFICATE');
-    expect(pk2.kid).to.equal('kid-a');
+    expect(pk2.kid).to.equal('r1');
   });
 });
 

--- a/lib/tests/server.ts
+++ b/lib/tests/server.ts
@@ -15,7 +15,6 @@ import { Binary } from '../tdf3/index.js';
 import { type KeyAccessObject } from '../tdf3/src/models/key-access.js';
 
 const Mocks = getMocks();
-const kid = 'kid-a';
 
 function range(start: number, end: number): Uint8Array {
   const result = [];
@@ -87,6 +86,7 @@ const kas: RequestListener = async (req, res) => {
       res.setHeader('Content-Type', 'application/json');
       res.statusCode = 200;
       const publicKey = 'ec:secp256r1' == algorithm ? Mocks.kasECCert : Mocks.kasPublicKey;
+      const kid = 'ec:secp256r1' == algorithm ? 'e1' : 'r1';
       res.end(JSON.stringify(v2 ? { kid, publicKey } : publicKey));
     } else if (url.pathname === '/v2/rewrap') {
       if (req.method !== 'POST') {

--- a/lib/tests/web/encodings/hex.test.ts
+++ b/lib/tests/web/encodings/hex.test.ts
@@ -3,12 +3,74 @@ import { expect } from '@esm-bundle/chai';
 import * as hex from '../../../src/encodings/hex.js';
 
 describe('hex', function () {
-  it('encodes', function () {
-    const encodedString = hex.encode('Hello world');
-    expect(encodedString).to.eql('48656c6c6f20776f726c64');
+  describe('encode', function () {
+    for (const { g, e } of [
+      { g: 'Hello world', e: '48656c6c6f20776f726c64' },
+      { g: '', e: '' },
+      { g: ' ', e: '20' },
+      { g: '\u0000', e: '00' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.encode(g)).to.eql(e);
+      });
+    }
   });
-  it('decodes', function () {
-    const string = hex.decode('466f6f');
-    expect(string).to.eql('Foo');
+  describe('encode throws', function () {
+    for (const { g, e } of [
+      { g: '🚩🚩🚩', e: 'invalid input' },
+      { g: '\uffff', e: 'invalid input' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(() => hex.encode(g)).to.throw(e);
+      });
+    }
+  });
+  describe('encodeArrayBuffer', function () {
+    for (const { g, e } of [
+      { g: [], e: '' },
+      { g: [0], e: '00' },
+      { g: [255], e: 'ff' },
+      { g: [255, 0, 32], e: 'ff0020' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.encodeArrayBuffer(new Uint8Array(g).buffer)).to.eql(e);
+      });
+    }
+  });
+
+  describe('decode', function () {
+    for (const { g, e } of [
+      { g: '48656c6c6f20776f726c64', e: 'Hello world' },
+      { g: '', e: '' },
+      { g: '20', e: ' ' },
+      { g: '466f6f', e: 'Foo' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.decode(g)).to.eql(e);
+      });
+    }
+  });
+  describe('decode throws', function () {
+    for (const { g, e } of [
+      { g: '🚩🚩🚩', e: 'invalid input' },
+      { g: 'ff ff', e: 'invalid input' },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(() => hex.decode(g)).to.throw(e);
+        expect(() => hex.decodeArrayBuffer(g)).to.throw(e);
+      });
+    }
+  });
+  describe('decodeArrayBuffer', function () {
+    for (const { g, e } of [
+      { g: '', e: [] },
+      { g: '00', e: [0] },
+      { g: 'ff', e: [255] },
+      { g: 'ff0020', e: [255, 0, 32] },
+    ]) {
+      it(`("${g}") => ${e}`, () => {
+        expect(hex.decodeArrayBuffer(g)).to.eql(new Uint8Array(e).buffer);
+      });
+    }
   });
 });

--- a/lib/tests/web/nano-roundtrip.test.ts
+++ b/lib/tests/web/nano-roundtrip.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { type AuthProvider, HttpRequest, withHeaders } from '../../src/auth/auth.js';
 
 import { NanoTDFClient } from '../../src/index.js';
+import NanoTDF from '../../src/nanotdf/NanoTDF.js';
 
 const authProvider = <AuthProvider>{
   updateClientPublicKey: async () => {
@@ -21,6 +22,9 @@ describe('Local roundtrip Tests', () => {
     const client = new NanoTDFClient({ authProvider, kasEndpoint });
     const cipherText = await client.encrypt('hello world');
     const client2 = new NanoTDFClient({ authProvider, kasEndpoint });
+    const nanotdfParsed = NanoTDF.from(cipherText);
+    expect(nanotdfParsed.header.kas.url).to.equal(kasEndpoint);
+    expect(nanotdfParsed.header.kas.getIdentifier()).to.equal('e1');
     const actual = await client2.decrypt(cipherText);
     expect(new TextDecoder().decode(actual)).to.be.equal('hello world');
   });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -1,0 +1,54 @@
+import { expect } from '@esm-bundle/chai';
+
+import ResourceLocator from '../../../../src/nanotdf/models/ResourceLocator.js';
+import ResourceLocatorIdentifierEnum from '../../../../src/nanotdf/enum/ResourceLocatorIdentifierEnum.js';
+import { hex } from '../../../../src/encodings/index.js';
+
+describe('NanoTDF.ResourceLocator', () => {
+  for (const { u, kid, idt } of [
+    { u: 'http://a', idt: ResourceLocatorIdentifierEnum.None },
+    { u: 'http://a', kid: 'r1', idt: ResourceLocatorIdentifierEnum.TwoBytes },
+    { u: 'http://a', kid: '12345678', idt: ResourceLocatorIdentifierEnum.EightBytes },
+    {
+      u: 'http://a',
+      kid: '12345678901234567890123456789012',
+      idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
+    },
+  ]) {
+    it(`ResourceLocator.parse("${u}", "${kid}")`, () => {
+      const rl = ResourceLocator.parse(u, kid);
+      expect(rl).to.have.property('identifierType', idt);
+      expect(rl).to.have.property('identifier', kid);
+    });
+  }
+
+  for (const { u, kid, v } of [
+    { u: 'http://a', v: '00 01 61' },
+    { u: 'https://a', v: '01 01 61' },
+    { u: 'http://a', kid: 'r1', v: '10 01 61 72 31' },
+    { u: 'https://a', kid: 'r1', v: '11 01 61 72 31' },
+    { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
+    {
+      u: 'http://a',
+      kid: '12345678901234567890123456789012',
+      v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32',
+    },
+  ]) {
+    it(`new ResourceLocator("${u}", "${kid}")`, () => {
+      const hexValue = v.replace(/\s/g, '');
+      const ab = hex.decodeArrayBuffer(hexValue);
+      const rl = new ResourceLocator(new Uint8Array(ab));
+      expect(rl).to.have.property('identifier', kid);
+      expect(rl).to.have.property('url', u);
+    });
+  }
+
+  for (const { u, kid, msg } of [
+    { u: 'http://a', kid: 'e0e0e0e0e0e0e0e0', msg: 'Unsupported identifier length: 16' },
+    { u: 'gopher://a', kid: 'r1', msg: 'protocol unsupported' },
+  ]) {
+    it(`invalid resource locator`, () => {
+      expect(() => ResourceLocator.parse(u, kid)).throw(msg);
+    });
+  }
+});

--- a/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
+++ b/lib/tests/web/nanotdf/ntdf-spec-basic-example.test.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from '@esm-bundle/chai';
+import { expect } from '@esm-bundle/chai';
 import { NanoTDF } from '../../../src/nanotdf/index.js';
 import PolicyTypeEnum from '../../../src/nanotdf/enum/PolicyTypeEnum.js';
 import bufferToHex from './helpers/bufferToHex.js';
@@ -7,24 +7,8 @@ import * as remoteFixture from '../../__fixtures__/nanotdf-spec-remote-example.j
 import * as embeddedFixture from '../../__fixtures__/nanotdf-spec-embedded-example.js';
 import * as plainEmbeddedFixture from '../../__fixtures__/nanotdf-spec-plain-embedded-example.js';
 import { EmbeddedHeader, PlainEmbeddedHeader, RemoteHeader } from '../../../src/types/index.js';
-import ResourceLocator from '../../../src/nanotdf/models/ResourceLocator.js';
-import ResourceLocatorIdentifierEnum from '../../../src/nanotdf/enum/ResourceLocatorIdentifierEnum.js';
 
 describe('NanoTDF', () => {
-  it('should parse the ResourceLocator Identifier', () => {
-    let rl = ResourceLocator.parse('http://localhost:8080', 'e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.TwoBytes);
-    assert.equal(rl.getIdentifier(), 'e0');
-    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.EightBytes);
-    assert.equal(rl.getIdentifier(), 'e0e0e0e0');
-    rl = ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
-    assert.equal(rl.identifierType, ResourceLocatorIdentifierEnum.ThirtyTwoBytes);
-    assert.equal(rl.getIdentifier(), 'e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0');
-    expect(() => ResourceLocator.parse('http://localhost:8080', 'e0e0e0e0e0e0e0e0')).throw(
-      'Unsupported identifier length: 16'
-    );
-  });
   for (const { policyType, fixture } of [
     { policyType: PolicyTypeEnum.Remote, fixture: remoteFixture },
     { policyType: PolicyTypeEnum.EmbeddedText, fixture: embeddedFixture },


### PR DESCRIPTION
While the previous fix allows parsing and decrypting files created with a kid, this adds the kid generation to the `NanoTDFClient.encrypt` method