### PR TITLE
chore(ci): Update nginx ingress helm chart

### DIFF
--- a/.github/workflows/roundtrip/Tiltfile
+++ b/.github/workflows/roundtrip/Tiltfile
@@ -49,7 +49,7 @@ def ingress(external_port="65432"):
         "k8s-in/ingress-nginx",
         flags=[
             "--version",
-            "4.0.16",
+            "4.11.2",
         ]
         + dict_to_helm_set_list(
             {


### PR DESCRIPTION
This should fix a 404 we are getting on the integration tests
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/5ad5191e-bfaa-4c61-bede-59f6e0c5e6c7">
