### PR TITLE
fix: identifier type extraction from protocol

### DIFF
--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -100,7 +100,7 @@ export default class ResourceLocator {
       buff.subarray(ResourceLocator.BODY_OFFSET, ResourceLocator.BODY_OFFSET + this.lengthOfBody)
     );
     // identifier
-    const identifierTypeNibble = this.protocol & 0xf0;
+    const identifierTypeNibble = this.protocol;
     if (identifierTypeNibble === ResourceLocator.IDENTIFIER_2_BYTE) {
       this.identifierType = ResourceLocatorIdentifierEnum.TwoBytes;
     } else if (identifierTypeNibble === ResourceLocator.IDENTIFIER_8_BYTE) {


### PR DESCRIPTION
Removed the bit masking operation on the protocol variable to directly use its value for determining the identifier type. This simplification potentially fixes any errors induced by incorrect bit manipulation of the protocol field.