### PR TITLE
fix(nano): Allow padding of kids

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -55,7 +55,7 @@
     "test": "npm run build && npm run test:with-server",
     "test:with-server": "node dist/web/tests/server.js & trap \"node dist/web/tests/stopServer.js\" EXIT; npm run test:mocha && npm run test:wtr && npm run test:browser && npm run coverage:merge",
     "test:browser": "npx webpack --config webpack.test.config.cjs && npx karma start karma.conf.cjs",
-    "test:mocha": "c8 --exclude=\"dist/web/tests/\" --exclude=\"dist/web/tdf3/src/utils/aws-lib-storage/\"  --exclude=\"dist/web/tests/**/*\" --report-dir=./coverage/mocha mocha 'dist/web/tests/mocha/**/*.spec.js' --file dist/web/tests/mocha/setup.js && npx c8 report --reporter=json --report-dir=./coverage/mocha",
+    "test:mocha": "c8 --exclude=\"dist/web/tests/\" --report-dir=./coverage/mocha mocha 'dist/web/tests/mocha/**/*.spec.js' --file dist/web/tests/mocha/setup.js && npx c8 report --reporter=json --report-dir=./coverage/mocha",
     "test:wtr": "web-test-runner",
     "watch": "(trap 'kill 0' SIGINT; npm run build && (npm run build:watch & npm run test -- --watch))"
   },

--- a/lib/package.json
+++ b/lib/package.json
@@ -55,7 +55,7 @@
     "test": "npm run build && npm run test:with-server",
     "test:with-server": "node dist/web/tests/server.js & trap \"node dist/web/tests/stopServer.js\" EXIT; npm run test:mocha && npm run test:wtr && npm run test:browser && npm run coverage:merge",
     "test:browser": "npx webpack --config webpack.test.config.cjs && npx karma start karma.conf.cjs",
-    "test:mocha": "c8 --exclude=\"dist/web/tests/\" --report-dir=./coverage/mocha mocha 'dist/web/tests/mocha/**/*.spec.js' --file dist/web/tests/mocha/setup.js && npx c8 report --reporter=json --report-dir=./coverage/mocha",
+    "test:mocha": "c8 --exclude=\"dist/web/tests/**/*\" --report-dir=./coverage/mocha mocha 'dist/web/tests/mocha/**/*.spec.js' --file dist/web/tests/mocha/setup.js && npx c8 report --reporter=json --report-dir=./coverage/mocha",
     "test:wtr": "web-test-runner",
     "watch": "(trap 'kill 0' SIGINT; npm run build && (npm run build:watch & npm run test -- --watch))"
   },

--- a/lib/src/access.ts
+++ b/lib/src/access.ts
@@ -75,7 +75,6 @@ export async function fetchECKasPubKey(kasEndpoint: string): Promise<KasPublicKe
         `unable to load KAS public key from [${pkUrlV2}]. Received [${kasPubKeyResponse.status}:${kasPubKeyResponse.statusText}]`
       );
     }
-    console.log('falling back to v1 key');
     // most likely a server that does not implement v2 endpoint, so no key identifier
     const pkUrlV1 = `${kasEndpoint}/kas_public_key?algorithm=ec:secp256r1`;
     const r2 = await fetch(pkUrlV1);
@@ -85,7 +84,6 @@ export async function fetchECKasPubKey(kasEndpoint: string): Promise<KasPublicKe
       );
     }
     const pem = await r2.json();
-    console.log('pem returned', pem);
     return {
       key: pemToCryptoPublicKey(pem),
       publicKey: pem,

--- a/lib/src/nanotdf/encrypt.ts
+++ b/lib/src/nanotdf/encrypt.ts
@@ -45,7 +45,7 @@ export default async function encrypt(
   );
 
   // Construct the kas locator
-  const kasResourceLocator = new ResourceLocator(kasInfo.url, kasInfo.kid);
+  const kasResourceLocator = ResourceLocator.fromURL(kasInfo.url, kasInfo.kid);
 
   // Auth tag length for policy and payload
   const authTagLengthInBytes = authTagLengthForCipher(DefaultParams.symmetricCipher) / 8;

--- a/lib/src/nanotdf/encrypt.ts
+++ b/lib/src/nanotdf/encrypt.ts
@@ -45,12 +45,7 @@ export default async function encrypt(
   );
 
   // Construct the kas locator
-  let kasResourceLocator;
-  if (kasInfo.kid) {
-    kasResourceLocator = ResourceLocator.parse(kasInfo.url, kasInfo.kid);
-  } else {
-    kasResourceLocator = ResourceLocator.parse(kasInfo.url);
-  }
+  const kasResourceLocator = new ResourceLocator(kasInfo.url, kasInfo.kid);
 
   // Auth tag length for policy and payload
   const authTagLengthInBytes = authTagLengthForCipher(DefaultParams.symmetricCipher) / 8;

--- a/lib/src/nanotdf/models/Header.ts
+++ b/lib/src/nanotdf/models/Header.ts
@@ -314,7 +314,7 @@ export default class Header {
    */
   getKasRewrapUrl(): string {
     try {
-      return `${rstrip(this.kas.url, "/")}/v2/rewrap`;
+      return `${rstrip(this.kas.url, '/')}/v2/rewrap`;
     } catch (e) {
       throw new Error(`Cannot construct KAS Rewrap URL: ${e.message}`);
     }

--- a/lib/src/nanotdf/models/Header.ts
+++ b/lib/src/nanotdf/models/Header.ts
@@ -11,6 +11,7 @@ import CurveNameEnum from '../enum/CurveNameEnum.js';
 import { lengthOfPublicKey } from '../helpers/calculateByCurve.js';
 import DefaultParams from './DefaultParams.js';
 import { InvalidEphemeralKeyError } from '../../errors.js';
+import { rstrip } from '../../utils.js';
 
 /**
  * NanoTDF Header
@@ -95,7 +96,7 @@ export default class Header {
      * @link https://github.com/virtru/nanotdf/blob/master/spec/index.md#3312-kas
      * @link https://github.com/virtru/nanotdf/blob/master/spec/index.md#341-resource-locator
      */
-    const kas = new ResourceLocator(buff.subarray(offset));
+    const kas = ResourceLocator.parse(buff.subarray(offset));
     offset += kas.length;
 
     /**
@@ -313,7 +314,7 @@ export default class Header {
    */
   getKasRewrapUrl(): string {
     try {
-      return `${this.kas.getUrl()}/v2/rewrap`;
+      return `${rstrip(this.kas.url, "/")}/v2/rewrap`;
     } catch (e) {
       throw new Error(`Cannot construct KAS Rewrap URL: ${e.message}`);
     }

--- a/lib/src/nanotdf/models/Policy/RemotePolicy.ts
+++ b/lib/src/nanotdf/models/Policy/RemotePolicy.ts
@@ -18,7 +18,7 @@ class RemotePolicy extends AbstractPolicy implements RemotePolicyInterface {
     useEcdsaBinding: boolean
   ): { offset: number; policy: RemotePolicy } {
     let offset = 0;
-    const resource = new ResourceLocator(buff);
+    const resource = ResourceLocator.parse(buff);
     offset += resource.offset;
 
     const { binding, newOffset: bindingOffset } = this.parseBinding(buff, useEcdsaBinding, offset);

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -32,8 +32,8 @@ export default class ResourceLocator {
     readonly lengthOfBody: number,
     readonly body: string,
     readonly offset: number,
-    readonly identifier?: string,
-    readonly identifierType: ResourceLocatorIdentifierEnum = ResourceLocatorIdentifierEnum.None
+    readonly id?: string,
+    readonly idType: ResourceLocatorIdentifierEnum = ResourceLocatorIdentifierEnum.None
   ) {}
 
   static fromURL(url: string, identifier?: string): ResourceLocator {
@@ -168,11 +168,9 @@ export default class ResourceLocator {
    * Return the contents of the Resource Locator in buffer
    */
   toBuffer(): Uint8Array {
-    const buffer = new Uint8Array(
-      ResourceLocator.BODY_OFFSET + this.body.length + this.identifierType
-    );
+    const buffer = new Uint8Array(ResourceLocator.BODY_OFFSET + this.body.length + this.idType);
     let idTypeNibble = 0;
-    switch (this.identifierType) {
+    switch (this.idType) {
       case ResourceLocatorIdentifierEnum.TwoBytes:
         idTypeNibble = ResourceLocator.IDENTIFIER_2_BYTE;
         break;
@@ -186,11 +184,8 @@ export default class ResourceLocator {
     buffer.set([this.protocol | idTypeNibble], ResourceLocator.PROTOCOL_OFFSET);
     buffer.set([this.lengthOfBody], ResourceLocator.LENGTH_OFFSET);
     buffer.set(new TextEncoder().encode(this.body), ResourceLocator.BODY_OFFSET);
-    if (this.identifier) {
-      buffer.set(
-        new TextEncoder().encode(this.identifier),
-        ResourceLocator.BODY_OFFSET + this.body.length
-      );
+    if (this.id) {
+      buffer.set(new TextEncoder().encode(this.id), ResourceLocator.BODY_OFFSET + this.body.length);
     }
     return buffer;
   }
@@ -201,7 +196,7 @@ export default class ResourceLocator {
    * Returns the identifier of the ResourceLocator or an empty string if no identifier is present.
    * @returns { string } Identifier of the resource locator.
    */
-  get kid(): string {
-    return this.identifier ?? '';
+  get identifier(): string {
+    return this.id ?? '';
   }
 }

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -120,7 +120,7 @@ export default class ResourceLocator {
         break;
       case ResourceLocatorIdentifierEnum.TwoBytes:
       case ResourceLocatorIdentifierEnum.EightBytes:
-      case ResourceLocatorIdentifierEnum.ThirtyTwoBytes:
+      case ResourceLocatorIdentifierEnum.ThirtyTwoBytes: {
         const kidStart = offset;
         offset = kidStart + identifierType.valueOf();
         if (offset > buff.length) {
@@ -136,6 +136,7 @@ export default class ResourceLocator {
           identifier = decoder.decode(kidSubarray);
         }
         break;
+      }
     }
     return new ResourceLocator(protocol, lengthOfBody, body, offset, identifier, identifierType);
   }
@@ -198,6 +199,6 @@ export default class ResourceLocator {
    * @returns { string } Identifier of the resource locator.
    */
   get kid(): string {
-    return this.identifier || '';
+    return this.identifier ?? '';
   }
 }

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -89,13 +89,13 @@ export default class ResourceLocator {
     let url = '';
     switch (protocol) {
       case ProtocolEnum.Http:
-        url = "http://" + body;
+        url = 'http://' + body;
         break;
       case ProtocolEnum.Https:
-        url = "https://" + body;
+        url = 'https://' + body;
         break;
       default:
-        throw new Error(`unsupported protocol type [${protocol}]`)
+        throw new Error(`unsupported protocol type [${protocol}]`);
     }
     // identifier
     const identifierTypeNibble = protocolAndIdentifierType & 0xf0;
@@ -157,7 +157,9 @@ export default class ResourceLocator {
    * Return the contents of the Resource Locator in buffer
    */
   toBuffer(): Uint8Array {
-    const buffer = new Uint8Array(ResourceLocator.BODY_OFFSET + this.body.length + this.identifierType);
+    const buffer = new Uint8Array(
+      ResourceLocator.BODY_OFFSET + this.body.length + this.identifierType
+    );
     let idTypeNibble = 0;
     switch (this.identifierType) {
       case ResourceLocatorIdentifierEnum.TwoBytes:
@@ -174,7 +176,10 @@ export default class ResourceLocator {
     buffer.set([this.lengthOfBody], ResourceLocator.LENGTH_OFFSET);
     buffer.set(new TextEncoder().encode(this.body), ResourceLocator.BODY_OFFSET);
     if (this.identifier) {
-      buffer.set(new TextEncoder().encode(this.identifier), ResourceLocator.BODY_OFFSET + this.body.length);
+      buffer.set(
+        new TextEncoder().encode(this.identifier),
+        ResourceLocator.BODY_OFFSET + this.body.length
+      );
     }
     return buffer;
   }

--- a/lib/src/nanotdf/models/ResourceLocator.ts
+++ b/lib/src/nanotdf/models/ResourceLocator.ts
@@ -66,11 +66,14 @@ export default class ResourceLocator {
       } else if (identifierLength <= 32) {
         return ResourceLocatorIdentifierEnum.ThirtyTwoBytes;
       }
-      throw new Error(`Unsupported identifier length: ${identifier.length}`);
+      throw new Error(`unsupported identifier length: ${identifier.length}`);
     })();
 
     // Create buffer to hold protocol, body length, body, and identifier
     const lengthOfBody = new TextEncoder().encode(body).length;
+    if (lengthOfBody == 0) {
+      throw new Error('url body empty');
+    }
     const identifierLength = identifierType.valueOf();
     const offset = ResourceLocator.BODY_OFFSET + lengthOfBody + identifierLength;
     return new ResourceLocator(protocol, lengthOfBody, body, offset, identifier, identifierType);

--- a/lib/tests/web/nano-roundtrip.test.ts
+++ b/lib/tests/web/nano-roundtrip.test.ts
@@ -25,7 +25,7 @@ describe('Local roundtrip Tests', () => {
     const nanotdfParsed = NanoTDF.from(cipherText);
 
     expect(nanotdfParsed.header.kas.url).to.equal(kasEndpoint);
-    expect(nanotdfParsed.header.kas.kid).to.equal('e1');
+    expect(nanotdfParsed.header.kas.identifier).to.equal('e1');
 
     const actual = await client2.decrypt(cipherText);
     expect(new TextDecoder().decode(actual)).to.be.equal('hello world');

--- a/lib/tests/web/nano-roundtrip.test.ts
+++ b/lib/tests/web/nano-roundtrip.test.ts
@@ -23,8 +23,10 @@ describe('Local roundtrip Tests', () => {
     const cipherText = await client.encrypt('hello world');
     const client2 = new NanoTDFClient({ authProvider, kasEndpoint });
     const nanotdfParsed = NanoTDF.from(cipherText);
+
     expect(nanotdfParsed.header.kas.url).to.equal(kasEndpoint);
-    expect(nanotdfParsed.header.kas.getIdentifier()).to.equal('e1');
+    expect(nanotdfParsed.header.kas.kid).to.equal('e1');
+
     const actual = await client2.decrypt(cipherText);
     expect(new TextDecoder().decode(actual)).to.be.equal('hello world');
   });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -47,13 +47,15 @@ describe('NanoTDF.ResourceLocator', () => {
     const ab = hex.decodeArrayBuffer(hexValue);
     it(`ResourceLocator.parse() => (${u}, "${kid}")`, () => {
       const rl = ResourceLocator.parse(new Uint8Array(ab));
-      expect(rl).to.have.property('identifier', kid);
+      expect(rl).to.have.property('id', kid);
+      expect(rl).to.have.property('identifier', kid ?? '');
       expect(rl).to.have.property('url', u);
     });
     it(`ResourceLocator.fromURL("${u}", "${kid}")`, () => {
       const rl = ResourceLocator.fromURL(u, kid);
-      expect(rl).to.have.property('identifierType', idt);
-      expect(rl).to.have.property('identifier', kid);
+      expect(rl).to.have.property('idType', idt);
+      expect(rl).to.have.property('id', kid);
+      expect(rl).to.have.property('identifier', kid ?? '');
       expect(hex.encodeArrayBuffer(rl.toBuffer())).to.eql(hexValue);
     });
   }

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -71,8 +71,12 @@ describe('NanoTDF.ResourceLocator', () => {
     });
   }
 
-  for (const { u, kid, msg } of [{ u: 'gopher://a', kid: 'r1', msg: 'unsupported' }]) {
-    it(`invalid resource locator`, () => {
+  for (const { u, kid, msg } of [
+    { u: 'gopher://a', kid: 'r1', msg: 'unsupported' },
+    { u: 'https://', kid: 'r1', msg: 'empty' },
+    { u: 'https://a', kid: '1234567890123456789012345678901234567890', msg: 'identifier length' },
+  ]) {
+    it(`invalid resource locator param throws ${msg}`, () => {
       expect(() => ResourceLocator.fromURL(u, kid)).throw(msg);
     });
   }

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -62,6 +62,7 @@ describe('NanoTDF.ResourceLocator', () => {
     { v: '03 01 61', msg: 'protocol' },
     { v: 'a1 01 61', msg: 'identifier' },
     { v: '00 00', msg: 'body' },
+    { v: '10 ff 61 61 ', msg: 'bounds' },
     { v: '10 01 61 61 ', msg: 'bounds' },
   ]) {
     it(`ResourceLocator.parse() throws ${msg}`, () => {

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -15,8 +15,8 @@ describe('NanoTDF.ResourceLocator', () => {
       idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
     },
   ]) {
-    it(`ResourceLocator.parse("${u}", "${kid}")`, () => {
-      const rl = new ResourceLocator(u, kid);
+    it(`ResourceLocator.fromURL("${u}", "${kid}")`, () => {
+      const rl = ResourceLocator.fromURL(u, kid);
       expect(rl).to.have.property('identifierType', idt);
       expect(rl).to.have.property('identifier', kid);
     });
@@ -35,7 +35,7 @@ describe('NanoTDF.ResourceLocator', () => {
     {
       u: 'http://a',
       kid: '1234567890123456',
-      v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 00 00 00 00 00 00 00 00 00 00 00 00 00',
+      v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00',
     },
     {
       u: 'http://a',
@@ -43,7 +43,7 @@ describe('NanoTDF.ResourceLocator', () => {
       v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32',
     },
   ]) {
-    it(`new ResourceLocator("${u}", "${kid}")`, () => {
+    it(`ResourceLocator.parse() => (${u}, "${kid}")`, () => {
       const hexValue = v.replace(/\s/g, '');
       const ab = hex.decodeArrayBuffer(hexValue);
       const rl = ResourceLocator.parse(new Uint8Array(ab));
@@ -52,9 +52,22 @@ describe('NanoTDF.ResourceLocator', () => {
     });
   }
 
+  for (const { v, msg } of [
+    { v: '03 01 61', msg: 'protocol' },
+    { v: 'a1 01 61', msg: 'identifier' },
+    { v: '00 00', msg: 'body' },
+    { v: '10 01 61 61 ', msg: 'bounds' },
+  ]) {
+    it(`ResourceLocator.parse() throws ${msg}`, () => {
+      const hexValue = v.replace(/\s/g, '');
+      const ab = hex.decodeArrayBuffer(hexValue);
+      expect(() => ResourceLocator.parse(new Uint8Array(ab))).to.throw(msg);
+    });
+  }
+
   for (const { u, kid, msg } of [{ u: 'gopher://a', kid: 'r1', msg: 'unsupported' }]) {
     it(`invalid resource locator`, () => {
-      expect(() => new ResourceLocator(u, kid)).throw(msg);
+      expect(() => ResourceLocator.fromURL(u, kid)).throw(msg);
     });
   }
 });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -52,9 +52,7 @@ describe('NanoTDF.ResourceLocator', () => {
     });
   }
 
-  for (const { u, kid, msg } of [
-    { u: 'gopher://a', kid: 'r1', msg: 'unsupported' },
-  ]) {
+  for (const { u, kid, msg } of [{ u: 'gopher://a', kid: 'r1', msg: 'unsupported' }]) {
     it(`invalid resource locator`, () => {
       expect(() => new ResourceLocator(u, kid)).throw(msg);
     });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -16,7 +16,7 @@ describe('NanoTDF.ResourceLocator', () => {
     },
   ]) {
     it(`ResourceLocator.parse("${u}", "${kid}")`, () => {
-      const rl = ResourceLocator.parse(u, kid);
+      const rl = new ResourceLocator(u, kid);
       expect(rl).to.have.property('identifierType', idt);
       expect(rl).to.have.property('identifier', kid);
     });
@@ -25,9 +25,18 @@ describe('NanoTDF.ResourceLocator', () => {
   for (const { u, kid, v } of [
     { u: 'http://a', v: '00 01 61' },
     { u: 'https://a', v: '01 01 61' },
+    { u: 'http://a', kid: 'a', v: '10 01 61 61 00' },
     { u: 'http://a', kid: 'r1', v: '10 01 61 72 31' },
+    { u: 'https://a', kid: 'a', v: '11 01 61 61 00' },
     { u: 'https://a', kid: 'r1', v: '11 01 61 72 31' },
     { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
+    { u: 'http://a', kid: '12345', v: '20 01 61 31 32 33 34 35 00 00 00' },
+    { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
+    {
+      u: 'http://a',
+      kid: '1234567890123456',
+      v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 00 00 00 00 00 00 00 00 00 00 00 00 00',
+    },
     {
       u: 'http://a',
       kid: '12345678901234567890123456789012',
@@ -37,18 +46,17 @@ describe('NanoTDF.ResourceLocator', () => {
     it(`new ResourceLocator("${u}", "${kid}")`, () => {
       const hexValue = v.replace(/\s/g, '');
       const ab = hex.decodeArrayBuffer(hexValue);
-      const rl = new ResourceLocator(new Uint8Array(ab));
+      const rl = ResourceLocator.parse(new Uint8Array(ab));
       expect(rl).to.have.property('identifier', kid);
       expect(rl).to.have.property('url', u);
     });
   }
 
   for (const { u, kid, msg } of [
-    { u: 'http://a', kid: 'e0e0e0e0e0e0e0e0', msg: 'Unsupported identifier length: 16' },
-    { u: 'gopher://a', kid: 'r1', msg: 'protocol unsupported' },
+    { u: 'gopher://a', kid: 'r1', msg: 'unsupported' },
   ]) {
     it(`invalid resource locator`, () => {
-      expect(() => ResourceLocator.parse(u, kid)).throw(msg);
+      expect(() => new ResourceLocator(u, kid)).throw(msg);
     });
   }
 });

--- a/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
+++ b/lib/tests/web/nanotdf/models/ResourceLocator.test.ts
@@ -5,50 +5,56 @@ import ResourceLocatorIdentifierEnum from '../../../../src/nanotdf/enum/Resource
 import { hex } from '../../../../src/encodings/index.js';
 
 describe('NanoTDF.ResourceLocator', () => {
-  for (const { u, kid, idt } of [
-    { u: 'http://a', idt: ResourceLocatorIdentifierEnum.None },
-    { u: 'http://a', kid: 'r1', idt: ResourceLocatorIdentifierEnum.TwoBytes },
-    { u: 'http://a', kid: '12345678', idt: ResourceLocatorIdentifierEnum.EightBytes },
+  for (const { u, kid, idt, v } of [
+    { u: 'http://a', idt: ResourceLocatorIdentifierEnum.None, v: '00 01 61' },
+    { u: 'https://a', idt: ResourceLocatorIdentifierEnum.None, v: '01 01 61' },
+    { u: 'http://a', kid: 'a', idt: ResourceLocatorIdentifierEnum.TwoBytes, v: '10 01 61 61 00' },
+    { u: 'http://a', kid: 'r1', idt: ResourceLocatorIdentifierEnum.TwoBytes, v: '10 01 61 72 31' },
+    { u: 'https://a', kid: 'a', idt: ResourceLocatorIdentifierEnum.TwoBytes, v: '11 01 61 61 00' },
+    { u: 'https://a', kid: 'r1', idt: ResourceLocatorIdentifierEnum.TwoBytes, v: '11 01 61 72 31' },
     {
       u: 'http://a',
-      kid: '12345678901234567890123456789012',
-      idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
+      kid: '12345678',
+      idt: ResourceLocatorIdentifierEnum.EightBytes,
+      v: '20 01 61 31 32 33 34 35 36 37 38',
     },
-  ]) {
-    it(`ResourceLocator.fromURL("${u}", "${kid}")`, () => {
-      const rl = ResourceLocator.fromURL(u, kid);
-      expect(rl).to.have.property('identifierType', idt);
-      expect(rl).to.have.property('identifier', kid);
-    });
-  }
-
-  for (const { u, kid, v } of [
-    { u: 'http://a', v: '00 01 61' },
-    { u: 'https://a', v: '01 01 61' },
-    { u: 'http://a', kid: 'a', v: '10 01 61 61 00' },
-    { u: 'http://a', kid: 'r1', v: '10 01 61 72 31' },
-    { u: 'https://a', kid: 'a', v: '11 01 61 61 00' },
-    { u: 'https://a', kid: 'r1', v: '11 01 61 72 31' },
-    { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
-    { u: 'http://a', kid: '12345', v: '20 01 61 31 32 33 34 35 00 00 00' },
-    { u: 'http://a', kid: '12345678', v: '20 01 61 31 32 33 34 35 36 37 38' },
+    {
+      u: 'http://a',
+      kid: '12345',
+      idt: ResourceLocatorIdentifierEnum.EightBytes,
+      v: '20 01 61 31 32 33 34 35 00 00 00',
+    },
+    {
+      u: 'http://a',
+      kid: '12345678',
+      idt: ResourceLocatorIdentifierEnum.EightBytes,
+      v: '20 01 61 31 32 33 34 35 36 37 38',
+    },
     {
       u: 'http://a',
       kid: '1234567890123456',
+      idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
       v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00',
     },
     {
       u: 'http://a',
       kid: '12345678901234567890123456789012',
+      idt: ResourceLocatorIdentifierEnum.ThirtyTwoBytes,
       v: '30 01 61 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32',
     },
   ]) {
+    const hexValue = v.replace(/\s/g, '');
+    const ab = hex.decodeArrayBuffer(hexValue);
     it(`ResourceLocator.parse() => (${u}, "${kid}")`, () => {
-      const hexValue = v.replace(/\s/g, '');
-      const ab = hex.decodeArrayBuffer(hexValue);
       const rl = ResourceLocator.parse(new Uint8Array(ab));
       expect(rl).to.have.property('identifier', kid);
       expect(rl).to.have.property('url', u);
+    });
+    it(`ResourceLocator.fromURL("${u}", "${kid}")`, () => {
+      const rl = ResourceLocator.fromURL(u, kid);
+      expect(rl).to.have.property('identifierType', idt);
+      expect(rl).to.have.property('identifier', kid);
+      expect(hex.encodeArrayBuffer(rl.toBuffer())).to.eql(hexValue);
     });
   }
 


### PR DESCRIPTION
- Allow kids to be any size less than 33 bytes
- refactor: replaces ResourceLocator.parse and constructor with factory methods with more sensible ones that call the same simple value-only constructor, instead of having to double-parse
- removes some stray console.logs I was using for debugging that i let get checked in
- fixes issue where sometimes queries sent to the server would have double slashes
- Adds more error checking and some tests for the error conditions (unsupported protocol and identifier type, undersized buffers)
- Deletes some duplicated methods